### PR TITLE
[feat] 회원가입시 Réponse 변경 

### DIFF
--- a/src/main/java/org/example/hugmeexp/global/infra/auth/controller/RegisterController.java
+++ b/src/main/java/org/example/hugmeexp/global/infra/auth/controller/RegisterController.java
@@ -7,9 +7,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.hugmeexp.global.common.response.Response;
 import org.example.hugmeexp.global.infra.auth.dto.request.RegisterRequest;
-import org.example.hugmeexp.global.infra.auth.dto.response.AuthResponse;
+import org.example.hugmeexp.global.infra.auth.dto.RegisterResponse;
 import org.example.hugmeexp.global.infra.auth.service.AuthService;
 import org.springframework.http.ResponseEntity;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,14 +25,24 @@ public class RegisterController
 {
     private final AuthService authService;
 
-    @Operation(summary = "회원 가입", description = "회원 가입 요청을 보냄. 회원 가입 성공시, 액세스 토큰과 리프레시 토큰을 응답함.")
+    @Operation(
+        summary = "회원 가입",
+        description = "회원 가입 요청을 보냅니다. 성공 시 회원 정보 객체를 반환합니다.",
+        responses = {
+            @ApiResponse(
+                responseCode = "201",
+                description = "회원가입 성공",
+                content = @Content(schema = @Schema(implementation = RegisterResponse.class))
+            )
+        }
+    )
     @PostMapping("/api/register")
-    public ResponseEntity<Response<AuthResponse>> register(@Valid @RequestBody RegisterRequest request)
+    public ResponseEntity<Response<RegisterResponse>> register(@Valid @RequestBody RegisterRequest request)
     {
         // 서비스에 비즈니스 로직 위임
-        AuthResponse result = authService.registerAndAuthenticate(request);
+        RegisterResponse result = authService.registerAndAuthenticate(request);
 
-        return ResponseEntity.ok(Response.<AuthResponse>builder()
+        return ResponseEntity.status(201).body(Response.<RegisterResponse>builder()
                 .message("회원가입에 성공했습니다")
                 .data(result)
                 .build());

--- a/src/main/java/org/example/hugmeexp/global/infra/auth/dto/RegisterResponse.java
+++ b/src/main/java/org/example/hugmeexp/global/infra/auth/dto/RegisterResponse.java
@@ -1,0 +1,27 @@
+package org.example.hugmeexp.global.infra.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.example.hugmeexp.domain.user.entity.User;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegisterResponse {
+    private Long id;
+    private String username;
+    private String name;
+    private String role;
+
+    public static RegisterResponse from(User user) {
+        return RegisterResponse.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .name(user.getName())
+                .role(user.getRole().toString())
+                .build();
+    }
+}

--- a/src/main/java/org/example/hugmeexp/global/infra/auth/service/AuthService.java
+++ b/src/main/java/org/example/hugmeexp/global/infra/auth/service/AuthService.java
@@ -3,6 +3,7 @@ package org.example.hugmeexp.global.infra.auth.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.hugmeexp.domain.user.entity.User;
+import org.example.hugmeexp.global.infra.auth.dto.RegisterResponse;
 import org.example.hugmeexp.global.infra.auth.dto.request.LoginRequest;
 import org.example.hugmeexp.global.infra.auth.dto.request.RegisterRequest;
 import org.example.hugmeexp.global.infra.auth.dto.request.RefreshRequest;
@@ -24,21 +25,14 @@ public class AuthService
 
     // 회원가입
     @Transactional
-    public AuthResponse registerAndAuthenticate(RegisterRequest request)
+    public RegisterResponse registerAndAuthenticate(RegisterRequest request)
     {
         // 1. 사용자 등록
         User user = credentialService.registerNewUser(request);
 
-        // 2. 토큰 생성 및 저장
-        String accessToken = tokenService.createAccessToken(user.getUsername(), user.getRole());
-        String refreshToken = tokenService.createRefreshToken(user.getUsername(), user.getRole());
-
-        // 3. 리프레시 토큰 저장
-        tokenService.saveRefreshToken(user.getUsername(), refreshToken, tokenService.getTokenRemainingTimeMillis(refreshToken));
-
-        // 4. 액세스 토큰, 리프레시 토큰 리턴
+        // 2. 회원가입 성공 정보 반환
         log.info("Sign-up successful - user: {}({})", user.getUsername(), user.getName());
-        return new AuthResponse(accessToken, refreshToken);
+        return RegisterResponse.from(user);
     }
 
     // 로그인

--- a/src/test/java/org/example/hugmeexp/global/auth/controller/RegisterControllerTest.java
+++ b/src/test/java/org/example/hugmeexp/global/auth/controller/RegisterControllerTest.java
@@ -51,10 +51,11 @@ class RegisterControllerTest {
     }
 
     @Test
-    @DisplayName("회원가입에 성공하면 200 상태코드와 토큰 정보를 반환한다.")
-    void shouldReturnOkAndTokens_whenRegisterUserSuccessfully() throws Exception {
+    @DisplayName("회원가입에 성공하면 201 상태코드와 회원 정보만 반환한다.")
+    void shouldReturnCreatedAndUserInfo_whenRegisterUserSuccessfully() throws Exception {
         // given
-        RegisterRequest request = new RegisterRequest(username, "validPass1!", "홍길동", phone);
+        String name= "홍길동";
+        RegisterRequest request = new RegisterRequest(username, "validPass1!", name, phone);
 
         // when
         ResultActions result = mockMvc.perform(post("/api/register")
@@ -62,9 +63,11 @@ class RegisterControllerTest {
                 .content(objectMapper.writeValueAsString(request)));
 
         // then
-        result.andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
-                .andExpect(jsonPath("$.data.refreshToken").isNotEmpty());
+        result.andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.id").isNumber())
+                .andExpect(jsonPath("$.data.username").value(username))
+                .andExpect(jsonPath("$.data.name").value(name))
+                .andExpect(jsonPath("$.data.role").isNotEmpty());
     }
 
     @Test

--- a/src/test/java/org/example/hugmeexp/global/auth/service/AuthServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/global/auth/service/AuthServiceTest.java
@@ -1,5 +1,7 @@
 package org.example.hugmeexp.global.auth.service;
 
+import org.example.hugmeexp.global.infra.auth.dto.RegisterResponse;
+
 import org.example.hugmeexp.domain.user.entity.User;
 import org.example.hugmeexp.domain.user.enums.UserRole;
 import org.example.hugmeexp.global.infra.auth.dto.request.LoginRequest;
@@ -38,18 +40,17 @@ class AuthServiceTest {
         User mockUser = User.createUser("testuser", "encodedPw", "홍길동", "010-1234-5678");
 
         given(credentialService.registerNewUser(request)).willReturn(mockUser);
-        given(tokenService.createAccessToken("testuser", mockUser.getRole())).willReturn("access-token");
-        given(tokenService.createRefreshToken("testuser", mockUser.getRole())).willReturn("refresh-token");
-        given(tokenService.getTokenRemainingTimeMillis("refresh-token")).willReturn(3600000L);
 
         // when
-        AuthResponse response = authService.registerAndAuthenticate(request);
+        RegisterResponse response = authService.registerAndAuthenticate(request);
 
         // then
-        assertThat(response.getAccessToken()).isEqualTo("access-token");
-        assertThat(response.getRefreshToken()).isEqualTo("refresh-token");
+        assertThat(response.getUsername()).isEqualTo("testuser");
+        assertThat(response.getName()).isEqualTo("홍길동");
+        assertThat(response.getRole()).isEqualTo(mockUser.getRole().toString());
 
-        verify(tokenService).saveRefreshToken("testuser", "refresh-token", 3600000L);
+        // 토큰 저장은 회원가입 이후 로그인에서 검증하거나, 별도 테스트에서 검증
+        // verify(tokenService).saveRefreshToken("testuser", "refresh-token", 3600000L);
     }
 
     @Test


### PR DESCRIPTION
## 📝 PR 요약
회원가입 API의 Response 구조 변경, access & refreshToken 대신 유저 정보를 리턴 

---

## 🔍 변경/추가 내용 상세 설명
- 회원가입 성공 메시지 및 상태코드와 response 데이터 변경
- 관련 테스트(`RegisterControllerTest`)의 jsonPath 및 검증 필드도 구조에 맞게 수정
- 기타 불필요한 mock, 타입 오류 등 테스트 코드 정비

---

## 📢 리뷰어에게 중점적으로 봐줬으면 하는 부분
- 회원가입 응답 구조 변경이 프론트엔드/문서 등과 호환되는지

---

## ✅ 체크리스트
- [x] 코드 스타일/컨벤션을 지켰습니다.
- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 테스트 코드를 추가/수정했습니다. (해당 시)
- [x] 문서/주석을 보충했습니다. (해당 시)

---

## 🔗 관련 이슈(있다면)
- #2

---

## 기타 참고자료/스크린샷(필요시)
- (변경된 응답 예시)
```json
{
  "status": 201,
  "message": "회원가입이 성공적으로 완료되었습니다.",
  "data": {
    "id": 1,
    "username": "newuser",
    "name": "홍길동",
    "role": "USER"
  }
}
```

---


