### PR TITLE
[feat] 유저 비밀번호 변경 API 추가 

### DIFF
--- a/src/main/java/org/example/hugmeexp/global/infra/auth/controller/AuthController.java
+++ b/src/main/java/org/example/hugmeexp/global/infra/auth/controller/AuthController.java
@@ -1,0 +1,37 @@
+package org.example.hugmeexp.global.infra.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.hugmeexp.global.infra.auth.dto.request.ModifyPasswordRequest;
+import org.example.hugmeexp.global.infra.auth.service.AuthService;
+import org.example.hugmeexp.global.common.response.Response;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth", description = "인증 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @Operation(summary = "비밀번호 변경", description = "기존 비밀번호를 확인하고 새 비밀번호로 변경합니다.")
+    @PutMapping("/password")
+    public ResponseEntity<Response> modifyPassword(@AuthenticationPrincipal UserDetails userDetails, @Valid @RequestBody ModifyPasswordRequest request) {
+      Boolean result = authService.modifyPassword(userDetails.getUsername(), request);
+
+      // TODO: 예외 처리 변경
+      if (result != true) {
+        return ResponseEntity.badRequest().build();
+      }
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/org/example/hugmeexp/global/infra/auth/controller/AuthController.java
+++ b/src/main/java/org/example/hugmeexp/global/infra/auth/controller/AuthController.java
@@ -25,13 +25,10 @@ public class AuthController {
 
     @Operation(summary = "비밀번호 변경", description = "기존 비밀번호를 확인하고 새 비밀번호로 변경합니다.")
     @PutMapping("/password")
-    public ResponseEntity<Response> modifyPassword(@AuthenticationPrincipal UserDetails userDetails, @Valid @RequestBody ModifyPasswordRequest request) {
-      Boolean result = authService.modifyPassword(userDetails.getUsername(), request);
-
-      // TODO: 예외 처리 변경
-      if (result != true) {
-        return ResponseEntity.badRequest().build();
-      }
-        return ResponseEntity.ok().build();
+    public ResponseEntity<Response> modifyPassword(@AuthenticationPrincipal UserDetails userDetails,
+        @Valid @RequestBody ModifyPasswordRequest request) {
+        // TODO: 예외 처리 변경
+        authService.modifyPassword(userDetails.getUsername(), request);
+        return ResponseEntity.ok(Response.builder().message("비밀번호가 성공적으로 변경되었습니다.").build());
     }
 }

--- a/src/main/java/org/example/hugmeexp/global/infra/auth/dto/request/ModifyPasswordRequest.java
+++ b/src/main/java/org/example/hugmeexp/global/infra/auth/dto/request/ModifyPasswordRequest.java
@@ -1,0 +1,32 @@
+package org.example.hugmeexp.global.infra.auth.dto.request;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ModifyPasswordRequest {
+
+    @Schema(description = "기존 비밀번호", example = "password123!")
+    @NotBlank(message = "기존 비밀번호를 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,32}$", message = "비밀번호는 영문, 숫자, 특수문자를 포함하여 8~32자로 입력해주세요.")
+    private String oldPassword;
+
+    @Schema(description = "새 비밀번호 (영문, 숫자, 특수문자 포함 8~32자)", example = "newPassword123!")
+    @NotBlank(message = "새 비밀번호를 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,32}$", message = "비밀번호는 영문, 숫자, 특수문자를 포함하여 8~32자로 입력해주세요.")
+    private String newPassword;
+
+    public static ModifyPasswordRequest of(String oldPassword, String newPassword) {
+        return new ModifyPasswordRequest(oldPassword, newPassword);
+    }
+
+}

--- a/src/main/java/org/example/hugmeexp/global/infra/auth/exception/PasswordMismatchException.java
+++ b/src/main/java/org/example/hugmeexp/global/infra/auth/exception/PasswordMismatchException.java
@@ -1,0 +1,11 @@
+package org.example.hugmeexp.global.infra.auth.exception;
+
+import org.example.hugmeexp.global.common.exception.BaseCustomException;
+import org.springframework.http.HttpStatus;
+
+// TOOO 나중에 예외처리 로직 변경 예장
+public class PasswordMismatchException extends BaseCustomException {
+    public PasswordMismatchException() {
+        super(HttpStatus.BAD_REQUEST, "현재 비밀번호가 틀렸습니다.", 400);
+    }
+}

--- a/src/main/java/org/example/hugmeexp/global/infra/auth/service/AuthService.java
+++ b/src/main/java/org/example/hugmeexp/global/infra/auth/service/AuthService.java
@@ -9,7 +9,6 @@ import org.example.hugmeexp.global.infra.auth.dto.request.ModifyPasswordRequest;
 import org.example.hugmeexp.global.infra.auth.dto.request.RegisterRequest;
 import org.example.hugmeexp.global.infra.auth.dto.request.RefreshRequest;
 import org.example.hugmeexp.global.infra.auth.dto.response.*;
-import org.example.hugmeexp.global.infra.auth.exception.LoginFailedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,15 +19,14 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class AuthService
-{
+public class AuthService {
+
     private final CredentialService credentialService;
     private final TokenService tokenService;
 
     // 회원가입
     @Transactional
-    public RegisterResponse registerAndAuthenticate(RegisterRequest request)
-    {
+    public RegisterResponse registerAndAuthenticate(RegisterRequest request) {
         // 1. 사용자 등록
         User user = credentialService.registerNewUser(request);
 
@@ -51,7 +49,8 @@ public class AuthService
         // 3. 토큰 생성 및 저장
         String accessToken = tokenService.createAccessToken(user.getUsername(), user.getRole());
         String refreshToken = tokenService.createRefreshToken(user.getUsername(), user.getRole());
-        tokenService.saveRefreshToken(user.getUsername(), refreshToken, tokenService.getTokenRemainingTimeMillis(refreshToken));
+        tokenService.saveRefreshToken(user.getUsername(), refreshToken,
+            tokenService.getTokenRemainingTimeMillis(refreshToken));
 
         // 4. 액세스 토큰, 리프레시 토큰 리턴
         log.info("Login successful - user: {}({})", user.getUsername(), user.getName());
@@ -80,19 +79,8 @@ public class AuthService
 
     // 비밀번호 변경
     @Transactional
-    public Boolean modifyPassword(String username, ModifyPasswordRequest request) {
-        
-        // TODO: 로그인 실패시 예외 처리 변경
-        try {
-            LoginRequest loginRequest = new LoginRequest(username, request.getOldPassword());
-            credentialService.login(loginRequest);
-
-           
-        }catch (LoginFailedException e){
-            throw  new RuntimeException("현재 비밀번호가 틀렸습니다.");
-        }
+    public void modifyPassword(String username, ModifyPasswordRequest request) {
         credentialService.updatePassword(username, request);
         log.info("Password changed successfully for user: {}", username);
-        return true;
     }
 }

--- a/src/main/java/org/example/hugmeexp/global/infra/auth/service/AuthService.java
+++ b/src/main/java/org/example/hugmeexp/global/infra/auth/service/AuthService.java
@@ -5,9 +5,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.hugmeexp.domain.user.entity.User;
 import org.example.hugmeexp.global.infra.auth.dto.RegisterResponse;
 import org.example.hugmeexp.global.infra.auth.dto.request.LoginRequest;
+import org.example.hugmeexp.global.infra.auth.dto.request.ModifyPasswordRequest;
 import org.example.hugmeexp.global.infra.auth.dto.request.RegisterRequest;
 import org.example.hugmeexp.global.infra.auth.dto.request.RefreshRequest;
 import org.example.hugmeexp.global.infra.auth.dto.response.*;
+import org.example.hugmeexp.global.infra.auth.exception.LoginFailedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -74,5 +76,23 @@ public class AuthService
     // 액세스 또는 리프레시 토큰에서 username을 추출하는 메서드
     public String getUsernameFromToken(String token) {
         return tokenService.getUsernameFromToken(token);
+    }
+
+    // 비밀번호 변경
+    @Transactional
+    public Boolean modifyPassword(String username, ModifyPasswordRequest request) {
+        
+        // TODO: 로그인 실패시 예외 처리 변경
+        try {
+            LoginRequest loginRequest = new LoginRequest(username, request.getOldPassword());
+            credentialService.login(loginRequest);
+
+           
+        }catch (LoginFailedException e){
+            throw  new RuntimeException("현재 비밀번호가 틀렸습니다.");
+        }
+        credentialService.updatePassword(username, request);
+        log.info("Password changed successfully for user: {}", username);
+        return true;
     }
 }

--- a/src/main/java/org/example/hugmeexp/global/infra/auth/service/CredentialService.java
+++ b/src/main/java/org/example/hugmeexp/global/infra/auth/service/CredentialService.java
@@ -10,6 +10,7 @@ import org.example.hugmeexp.global.infra.auth.dto.request.LoginRequest;
 import org.example.hugmeexp.global.infra.auth.dto.request.ModifyPasswordRequest;
 import org.example.hugmeexp.global.infra.auth.dto.request.RegisterRequest;
 import org.example.hugmeexp.global.infra.auth.exception.LoginFailedException;
+import org.example.hugmeexp.global.infra.auth.exception.PasswordMismatchException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -67,7 +68,7 @@ public class CredentialService {
                 .orElseThrow(UserNotFoundException::new);
 
         if (!passwordEncoder.matches(request.getOldPassword(), user.getPassword())) {
-            throw new LoginFailedException(); // PASSWORD_MISMATCH와 같은 더 구체적인 예외를 사용할 수 있습니다.
+            throw new PasswordMismatchException();
         }
 
         String newEncodedPassword = passwordEncoder.encode(request.getNewPassword());

--- a/src/main/java/org/example/hugmeexp/global/infra/auth/service/CredentialService.java
+++ b/src/main/java/org/example/hugmeexp/global/infra/auth/service/CredentialService.java
@@ -3,9 +3,11 @@ package org.example.hugmeexp.global.infra.auth.service;
 import lombok.RequiredArgsConstructor;
 import org.example.hugmeexp.domain.user.entity.User;
 import org.example.hugmeexp.domain.user.exception.PhoneNumberDuplicatedException;
+import org.example.hugmeexp.domain.user.exception.UserNotFoundException;
 import org.example.hugmeexp.domain.user.exception.UsernameDuplicatedException;
 import org.example.hugmeexp.domain.user.repository.UserRepository;
 import org.example.hugmeexp.global.infra.auth.dto.request.LoginRequest;
+import org.example.hugmeexp.global.infra.auth.dto.request.ModifyPasswordRequest;
 import org.example.hugmeexp.global.infra.auth.dto.request.RegisterRequest;
 import org.example.hugmeexp.global.infra.auth.exception.LoginFailedException;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -56,5 +58,20 @@ public class CredentialService {
     private void validateDuplicateUser(String username, String phoneNumber) {
         if (userRepository.existsByUsername(username)) throw new UsernameDuplicatedException();
         if (userRepository.existsByPhoneNumber(phoneNumber)) throw new PhoneNumberDuplicatedException();
+    }
+
+    // 비밀번호 변경
+    @Transactional
+    public void updatePassword(String username, ModifyPasswordRequest request) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(UserNotFoundException::new);
+
+        if (!passwordEncoder.matches(request.getOldPassword(), user.getPassword())) {
+            throw new LoginFailedException(); // PASSWORD_MISMATCH와 같은 더 구체적인 예외를 사용할 수 있습니다.
+        }
+
+        String newEncodedPassword = passwordEncoder.encode(request.getNewPassword());
+        user.changePassword(newEncodedPassword);
+        // @Transactional에 의해 변경 감지(dirty checking)가 일어나므로 명시적인 save 호출은 필요 없습니다.
     }
 }

--- a/src/test/java/org/example/hugmeexp/global/auth/controller/AuthControllerTest.java
+++ b/src/test/java/org/example/hugmeexp/global/auth/controller/AuthControllerTest.java
@@ -1,0 +1,94 @@
+package org.example.hugmeexp.global.auth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.hugmeexp.global.infra.auth.controller.AuthController;
+import org.example.hugmeexp.global.infra.auth.dto.request.ModifyPasswordRequest;
+import org.example.hugmeexp.global.infra.auth.service.AuthService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = AuthController.class,
+    excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.REGEX, pattern = "org.example.hugmeexp.global.security.config.*")
+    }
+)
+@TestPropertySource(properties = {
+        "jwt.secret=aHR0cHM6Ly9naXRodWIuY29tL3NldW5nd29vay9qd3QtYXBpLXNlcnZlci1zYW1wbGUteW91LWNhbi11c2UtdGhpcy1sb25nLXNlY3JldC1rZXktZm9yLWVuY3J5cHRpb24K",
+        "jwt.access-token-expiration=10000",
+        "jwt.refresh-token-expiration=60000"
+})
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AuthController 테스트")
+class AuthControllerTest {
+
+    private static final String BASE_URL = "/api/auth";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private AuthService authService;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @Nested
+    @DisplayName("비밀번호 변경 API 테스트")
+    class ModifyPasswordTest {
+
+        @Test
+        @DisplayName("비밀번호 변경에 성공한다")
+        @WithMockUser(username = "testuser@example.com")
+        void modifyPassword_Success() throws Exception {
+            // Given
+            ModifyPasswordRequest request = ModifyPasswordRequest.of("oldPassword1!", "newPassword1!");
+            given(authService.modifyPassword(anyString(), any(ModifyPasswordRequest.class))).willReturn(true);
+
+            // When & Then
+            mockMvc.perform(put(BASE_URL + "/password")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("기존 비밀번호가 틀리면 비밀번호 변경에 실패한다")
+        @WithMockUser(username = "testuser@example.com")
+        void modifyPassword_Failure() throws Exception {
+            // Given
+            ModifyPasswordRequest request = ModifyPasswordRequest.of("wrongPassword1!", "newPassword1!");
+            given(authService.modifyPassword(anyString(), any(ModifyPasswordRequest.class))).willReturn(false);
+
+            // When & Then
+            mockMvc.perform(put(BASE_URL + "/password")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+}

--- a/src/test/java/org/example/hugmeexp/global/auth/controller/AuthControllerTest.java
+++ b/src/test/java/org/example/hugmeexp/global/auth/controller/AuthControllerTest.java
@@ -20,9 +20,10 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import org.example.hugmeexp.global.infra.auth.exception.PasswordMismatchException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -65,7 +66,7 @@ class AuthControllerTest {
         void modifyPassword_Success() throws Exception {
             // Given
             ModifyPasswordRequest request = ModifyPasswordRequest.of("oldPassword1!", "newPassword1!");
-            given(authService.modifyPassword(anyString(), any(ModifyPasswordRequest.class))).willReturn(true);
+
 
             // When & Then
             mockMvc.perform(put(BASE_URL + "/password")
@@ -81,7 +82,7 @@ class AuthControllerTest {
         void modifyPassword_Failure() throws Exception {
             // Given
             ModifyPasswordRequest request = ModifyPasswordRequest.of("wrongPassword1!", "newPassword1!");
-            given(authService.modifyPassword(anyString(), any(ModifyPasswordRequest.class))).willReturn(false);
+            doThrow(new PasswordMismatchException()).when(authService).modifyPassword(anyString(), any(ModifyPasswordRequest.class));
 
             // When & Then
             mockMvc.perform(put(BASE_URL + "/password")


### PR DESCRIPTION
# 🚀 What’s this PR about?
 유저 비밀번호 변경 기능을 추가합니다.

# 🛠️ What’s been done?

- **주요 변경사항:**
  - 사용자가 현재 비밀번호와 새 비밀번호를 입력하여 비밀번호를 변경할 수 있는 API 엔드포인트를 추가했습니다.
  - 비밀번호 변경 로직을 처리하는 서비스를 구현했습니다.
  - 관련 컨트롤러 및 서비스에 대한 테스트 코드를 작성했습니다.

# 🧪 Testing Details

AuthControllerTest`에 비밀번호 변경 성공 및 실패 케이스에 대한 테스트 코드를 추가했으며, 모든 테스트가 통과되었습니다.

# 👀 Checkpoints for Reviewers

- **리뷰 시 확인할 사항:**
  - 비밀번호 암호화 로직이 올바르게 적용되었는지 확인 부탁드립니다.
  - 예외 처리 로직이 적절한지 검토해 주세요.

# 📚 References & Resources

- **참고 자료:** 해당 없음

# 🎯 Related Issues

- #10


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 비밀번호 변경 API 엔드포인트가 추가되어 사용자가 기존 비밀번호를 새 비밀번호로 변경할 수 있습니다.
  * 비밀번호 변경 요청 시 입력값에 대한 유효성 검사가 강화되었습니다.
  * 비밀번호 변경 실패 시 명확한 오류 메시지가 제공됩니다.

* **버그 수정**
  * 비밀번호 변경 시 기존 비밀번호가 올바르지 않을 경우 400 Bad Request 응답이 반환됩니다.

* **테스트**
  * 비밀번호 변경 기능에 대한 성공 및 실패 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->