### PR TITLE
채용 공고 리스트 조회 기능

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/controller/RecruitmentController.java
@@ -1,0 +1,43 @@
+package org.example.hugmeexp.domain.recruitment.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO;
+import org.example.hugmeexp.domain.recruitment.dto.RecruitmentSearchConditionDTO;
+import org.example.hugmeexp.domain.recruitment.service.RecruitmentService;
+import org.example.hugmeexp.global.common.response.Response;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j    // 로깅 어노테이션
+@RestController
+@RequestMapping("/api/recruitments")
+@RequiredArgsConstructor
+@Tag(name = "Recruitments" , description = "채용 공고 관련 API")
+public class RecruitmentController {
+
+    private final RecruitmentService recruitmentService;
+
+    @Operation(summary = "채용 공고 목록 조회", description = "채용 공고 목록을 조회합니다")
+    @GetMapping
+    public ResponseEntity<Response<List<RecruitmentResponseDTO>>> listRecruitments(
+            @ModelAttribute RecruitmentSearchConditionDTO conditionDTO) {
+
+        List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(conditionDTO);
+
+        Response<List<RecruitmentResponseDTO>> response = Response.<List<RecruitmentResponseDTO>>builder()
+                .message("채용 공고 목록 조회 성공")
+                .data(result)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/controller/RecruitmentController.java
@@ -2,6 +2,7 @@ package org.example.hugmeexp.domain.recruitment.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO;
@@ -29,7 +30,7 @@ public class RecruitmentController {
     @Operation(summary = "채용 공고 목록 조회", description = "채용 공고 목록을 조회합니다")
     @GetMapping
     public ResponseEntity<Response<List<RecruitmentResponseDTO>>> listRecruitments(
-            @ModelAttribute RecruitmentSearchConditionDTO conditionDTO) {
+            @Valid @ModelAttribute RecruitmentSearchConditionDTO conditionDTO) {
 
         List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(conditionDTO);
 

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentResponseDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentResponseDTO.java
@@ -1,0 +1,56 @@
+package org.example.hugmeexp.domain.recruitment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.hugmeexp.domain.recruitment.entity.Recruitment;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Builder
+public class RecruitmentResponseDTO {
+
+    private Long id;
+    private String title;
+    private String companyName;
+    private String companyImageUrl;
+    private LocalDateTime dueDate;
+    private Integer experience;
+    private String workLocation;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+
+    // jpal에서 사용되는 생성자
+    public RecruitmentResponseDTO(Long id, String title, String companyName, String companyImageUrl,
+                                  LocalDateTime dueDate, Integer experience, String workLocation,
+                                  BigDecimal latitude, BigDecimal longitude) {
+        this.id = id;
+        this.title = title;
+        this.companyName = companyName;
+        this.companyImageUrl = companyImageUrl;
+        this.dueDate = dueDate;
+        this.experience = experience;
+        this.workLocation = workLocation;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    // 서비스 단에서 REcruitment 엔티티를 DTO로 변환하는 메서드
+    public static RecruitmentResponseDTO from(Recruitment recruitment) {
+        return RecruitmentResponseDTO.builder()
+                .id(recruitment.getId())
+                .title(recruitment.getTitle())
+                .companyName(recruitment.getCompany().getCompanyName())
+                .companyImageUrl(recruitment.getCompany().getCompanyImageUrl())
+                .dueDate(recruitment.getDueDate())
+                .experience(recruitment.getExperience())
+                .workLocation(recruitment.getWorkLocation())
+                .latitude(recruitment.getCompany().getLatitude())
+                .longitude(recruitment.getCompany().getLongitude())
+                .build();
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentResponseDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentResponseDTO.java
@@ -20,10 +20,10 @@ public class RecruitmentResponseDTO {
     private LocalDateTime dueDate;
     private Integer experience;
     private String workLocation;
-    private BigDecimal latitude;
-    private BigDecimal longitude;
+    private BigDecimal latitude; // 위도
+    private BigDecimal longitude; // 경도
 
-    // jpal에서 사용되는 생성자
+    // JPA 에서 사용되는 생성자
     public RecruitmentResponseDTO(Long id, String title, String companyName, String companyImageUrl,
                                   LocalDateTime dueDate, Integer experience, String workLocation,
                                   BigDecimal latitude, BigDecimal longitude) {
@@ -38,7 +38,7 @@ public class RecruitmentResponseDTO {
         this.longitude = longitude;
     }
 
-    // 서비스 단에서 REcruitment 엔티티를 DTO로 변환하는 메서드
+    // 서비스 단에서 Recruitment 엔티티를 DTO로 변환하는 메서드
     public static RecruitmentResponseDTO from(Recruitment recruitment) {
         return RecruitmentResponseDTO.builder()
                 .id(recruitment.getId())

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentResponseDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentResponseDTO.java
@@ -1,6 +1,5 @@
 package org.example.hugmeexp.domain.recruitment.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentSearchConditionDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentSearchConditionDTO.java
@@ -1,0 +1,29 @@
+package org.example.hugmeexp.domain.recruitment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RecruitmentSearchConditionDTO {
+
+    private Integer salaryMin;
+    private Integer salaryMax;
+    private Integer experience;
+    private Integer education;
+    private List<Long> techStacks;
+    private String workLocation;
+    private List<Long> tags;
+    private BigDecimal topLeftLat;
+    private BigDecimal topLeftLng;
+    private BigDecimal bottomRightLat;
+    private BigDecimal bottomRightLng;
+
+}

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentSearchConditionDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentSearchConditionDTO.java
@@ -11,7 +11,7 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
+@Builder(toBuilder = true)
 public class RecruitmentSearchConditionDTO {
 
     private Integer salaryMin;
@@ -21,9 +21,12 @@ public class RecruitmentSearchConditionDTO {
     private List<Long> techStacks;
     private String workLocation;
     private List<Long> tags;
-    private BigDecimal topLeftLat;
-    private BigDecimal topLeftLng;
-    private BigDecimal bottomRightLat;
-    private BigDecimal bottomRightLng;
+    private BigDecimal topLeftLat; // 북쪽(큰 값)
+    private BigDecimal topLeftLng; // 서쪽(작은 값)
+    private BigDecimal bottomRightLat; // 남쪽(작은 값)
+    private BigDecimal bottomRightLng; // 동쪽(큰 값)
+
+    private Long techStackCount;
+    private Long tagCount;
 
 }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/entity/Company.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/entity/Company.java
@@ -1,0 +1,43 @@
+package org.example.hugmeexp.domain.recruitment.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Table(name = "company")
+public class Company {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String companyName;
+
+    @Column(nullable = false)
+    private String companyAddress;
+
+    @Column(nullable = false)
+    private BigDecimal latitude; // 위도
+    @Column(nullable = false)
+    private BigDecimal longitude; // 경도
+
+    @Column(nullable = false)
+    private LocalDate establishmentDate;
+
+    private String companyImageUrl; // 회사 이미지 URL
+
+    @Column(columnDefinition = "TEXT") // TEXT 타입으로도 저장 가능(길이 제한 없음)
+    private String companyDescription;
+
+}

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/entity/Recruitment.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/entity/Recruitment.java
@@ -27,9 +27,9 @@ public class Recruitment {
     private String title;
 
     @Column(nullable = false)
-    private int education;
+    private Integer education;
     @Column(nullable = false)
-    private int experience;
+    private Integer experience;
 
     private String qualification; // 자격 요건
     private String advantage; // 우대 사항
@@ -40,15 +40,15 @@ public class Recruitment {
     private BigDecimal longitude; // 경도
 
     @Column(name = "salary_min")
-    private int salaryMin;
+    private Integer salaryMin;
 
     @Column(name = "salary_max")
-    private int salaryMax;
+    private Integer salaryMax;
 
     private String link;
 
     @Enumerated(EnumType.STRING)
-    private SourceType source; // 0: 원티드, 1: 점핏
+    private SourceType source; // WANTED: 원티드, JUMPIT: 점핏
 
     private LocalDateTime dueDate;
 
@@ -57,13 +57,10 @@ public class Recruitment {
     private Company company;
 
     // 중간 테이블 관계
-    @OneToMany(mappedBy = "recruitment")
+    @OneToMany(mappedBy = "recruitment", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TechStack> techStacks;
 
-    @OneToMany(mappedBy = "recruitment")
+    @OneToMany(mappedBy = "recruitment", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Tag> tags;
-
-
-
 
 }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/entity/Recruitment.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/entity/Recruitment.java
@@ -1,0 +1,69 @@
+package org.example.hugmeexp.domain.recruitment.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.hugmeexp.domain.recruitment.enums.SourceType;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Table(name = "recruitment")
+public class Recruitment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private int education;
+    @Column(nullable = false)
+    private int experience;
+
+    private String qualification; // 자격 요건
+    private String advantage; // 우대 사항
+    private String welfare; // 복지 혜택
+    private String workLocation; // 근무지
+
+    private BigDecimal latitude; // 위도
+    private BigDecimal longitude; // 경도
+
+    @Column(name = "salary_min")
+    private int salaryMin;
+
+    @Column(name = "salary_max")
+    private int salaryMax;
+
+    private String link;
+
+    @Enumerated(EnumType.STRING)
+    private SourceType source; // 0: 원티드, 1: 점핏
+
+    private LocalDateTime dueDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id", nullable = false)
+    private Company company;
+
+    // 중간 테이블 관계
+    @OneToMany(mappedBy = "recruitment")
+    private List<TechStack> techStacks;
+
+    @OneToMany(mappedBy = "recruitment")
+    private List<Tag> tags;
+
+
+
+
+}

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/entity/Tag.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/entity/Tag.java
@@ -1,0 +1,28 @@
+package org.example.hugmeexp.domain.recruitment.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Table(name = "tag")
+public class Tag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recruitment_id")
+    private Recruitment recruitment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_item_id")
+    private TagItem tagItem;
+}

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/entity/Tag.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/entity/Tag.java
@@ -19,10 +19,10 @@ public class Tag {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "recruitment_id")
+    @JoinColumn(name = "recruitment_id", nullable = false)
     private Recruitment recruitment;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "tag_item_id")
+    @JoinColumn(name = "tag_item_id", nullable = false)
     private TagItem tagItem;
 }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/entity/TagItem.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/entity/TagItem.java
@@ -18,5 +18,6 @@ public class TagItem {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private String tagName;
 }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/entity/TagItem.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/entity/TagItem.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(toBuilder = true)
-@Table(name = "tagItem")
+@Table(name = "tag_item")
 public class TagItem {
 
     @Id

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/entity/TagItem.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/entity/TagItem.java
@@ -1,0 +1,22 @@
+package org.example.hugmeexp.domain.recruitment.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Table(name = "tagItem")
+public class TagItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String tagName;
+}

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/entity/TechItem.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/entity/TechItem.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(toBuilder = true)
-@Table(name = "techItem")
+@Table(name = "tech_item")
 public class TechItem {
 
     @Id

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/entity/TechItem.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/entity/TechItem.java
@@ -1,16 +1,13 @@
 package org.example.hugmeexp.domain.recruitment.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder(toBuilder = true)
+@Builder(access = AccessLevel.PRIVATE)
 @Table(name = "tech_item")
 public class TechItem {
 
@@ -18,7 +15,10 @@ public class TechItem {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private String englishName;
+    @Column(nullable = false)
     private String koreanName;
+    @Column(nullable = false)
     private String iconUrl;
 }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/entity/TechItem.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/entity/TechItem.java
@@ -1,0 +1,24 @@
+package org.example.hugmeexp.domain.recruitment.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Table(name = "techItem")
+public class TechItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String englishName;
+    private String koreanName;
+    private String iconUrl;
+}

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/entity/TechStack.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/entity/TechStack.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(toBuilder = true)
-@Table(name = "techStack")
+@Table(name = "tech_stack")
 public class TechStack {
 
     @Id

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/entity/TechStack.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/entity/TechStack.java
@@ -1,0 +1,30 @@
+package org.example.hugmeexp.domain.recruitment.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Table(name = "techStack")
+public class TechStack {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 공고 FK
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recruitment_id")
+    private Recruitment recruitment;
+
+    // 기술스택 FK
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tech_item_id")
+    private TechItem techItem;
+}

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/enums/SourceType.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/enums/SourceType.java
@@ -1,0 +1,17 @@
+package org.example.hugmeexp.domain.recruitment.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@AllArgsConstructor
+@ToString
+public enum SourceType {
+
+    WANTED("원티드"),
+    JUMPIT("점핏");
+
+    private final String label;
+
+}

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.math.BigDecimal;
 import java.util.List;
 
 @Repository

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
@@ -31,8 +31,8 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
               (:#{#cond.topLeftLng} IS NULL OR r.longitude >= :#{#cond.topLeftLng}) AND
               (:#{#cond.bottomRightLat} IS NULL OR r.latitude <= :#{#cond.bottomRightLat}) AND
               (:#{#cond.bottomRightLng} IS NULL OR r.longitude <= :#{#cond.bottomRightLng}) AND
-              (:#{#cond.techStacks == null or #cond.techStacks.isEmpty()} OR ts.id IN :#{#cond.techStacks}) AND
-              (:#{#cond.tags == null or #cond.tags.isEmpty()} OR t.id IN :#{#cond.tags})
+              (:#{#cond.techStacks} IS NULL OR ts.id IN :#{#cond.techStacks}) AND
+              (:#{#cond.tags} IS NULL OR t.id IN :#{#cond.tags})
         GROUP BY r.id, r.title, c.companyName, c.companyImageUrl, r.dueDate, r.experience,
                  r.workLocation, r.latitude, r.longitude
         HAVING (:#{#cond.techStacks} IS NULL OR COUNT(DISTINCT ts.id) = :#{#cond.techStackCount}) AND

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
@@ -1,6 +1,7 @@
 package org.example.hugmeexp.domain.recruitment.repository;
 
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO;
+import org.example.hugmeexp.domain.recruitment.dto.RecruitmentSearchConditionDTO;
 import org.example.hugmeexp.domain.recruitment.entity.Recruitment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,42 +14,31 @@ import java.util.List;
 @Repository
 public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> {
 
-    @Query("SELECT new org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO( " +
-            "r.id, r.title, c.companyName, c.companyImageUrl, r.dueDate, r.experience, " +
-            "r.workLocation, r.latitude, r.longitude " +
-            ") " +
-            "FROM Recruitment r " +
-            "JOIN r.company c " +
-            "LEFT JOIN r.techStacks ts " +
-            "LEFT JOIN r.tags t " +
-            "WHERE (:salaryMin IS NULL OR r.salaryMin >= :salaryMin) AND " +
-                    "(:salaryMax IS NULL OR r.salaryMax <= :salaryMax) AND " +
-                    "(:experience IS NULL OR r.experience = :experience) AND " +
-                    "(:education IS NULL OR r.education = :education) AND " +
-                    "(:workLocation IS NULL OR r.workLocation LIKE %:workLocation%) AND " +
-                    "(:topLeftLat IS NULL OR r.latitude >= :topLeftLat) AND " +
-                    "(:topLeftLng IS NULL OR r.longitude <= :topLeftLng) AND " +
-                    "(:bottomRightLat IS NULL OR r.latitude <= :bottomRightLat) AND " +
-                    "(:bottomRightLng IS NULL OR r.longitude >= :bottomRightLng) AND " +
-                    "(:techStacks IS NULL OR ts.id IN :techStacks) AND " +
-                    "(:tags IS NULL OR t.id IN :tags) " +
-            "GROUP BY r.id, r.title, c.companyName, c.companyImageUrl, r.dueDate, r.experience, " +
-                        "r.workLocation, r.latitude, r.longitude " +
-            "HAVING (:techStacks IS NULL OR COUNT(DISTINCT ts.id) = :techStackCount) AND " +
-                    "(:tags IS NULL OR COUNT(DISTINCT t.id) = :tagCount)")
-    List<RecruitmentResponseDTO> findBySearchConditions(
-            Integer salaryMin,
-            Integer salaryMax,
-            Integer experience,
-            Integer education,
-            String workLocation,
-            BigDecimal topLeftLat,
-            BigDecimal topLeftLng,
-            BigDecimal bottomRightLat,
-            BigDecimal bottomRightLng,
-            List<Long> techStacks,
-            List<Long> tags,
-            @Param("techStackCount") Long techStackCount,
-            @Param("tagCount") Long tagCount
-    );
+    @Query("""
+        SELECT new org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO(
+            r.id, r.title, c.companyName, c.companyImageUrl, r.dueDate, r.experience,
+            r.workLocation, r.latitude, r.longitude
+        )
+        FROM Recruitment r
+        JOIN r.company c
+        LEFT JOIN r.techStacks ts
+        LEFT JOIN r.tags t
+        WHERE (:#{#cond.salaryMin} IS NULL OR r.salaryMin >= :#{#cond.salaryMin}) AND
+              (:#{#cond.salaryMax} IS NULL OR r.salaryMax <= :#{#cond.salaryMax}) AND
+              (:#{#cond.experience} IS NULL OR r.experience = :#{#cond.experience}) AND
+              (:#{#cond.education} IS NULL OR r.education = :#{#cond.education}) AND
+              (:#{#cond.workLocation} IS NULL OR r.workLocation LIKE %:#{#cond.workLocation}%) AND
+              (:#{#cond.topLeftLat} IS NULL OR r.latitude >= :#{#cond.topLeftLat}) AND
+              (:#{#cond.topLeftLng} IS NULL OR r.longitude >= :#{#cond.topLeftLng}) AND
+              (:#{#cond.bottomRightLat} IS NULL OR r.latitude <= :#{#cond.bottomRightLat}) AND
+              (:#{#cond.bottomRightLng} IS NULL OR r.longitude <= :#{#cond.bottomRightLng}) AND
+              (:#{#cond.techStacks} IS NULL OR ts.id IN :#{#cond.techStacks}) AND
+              (:#{#cond.tags} IS NULL OR t.id IN :#{#cond.tags})
+        GROUP BY r.id, r.title, c.companyName, c.companyImageUrl, r.dueDate, r.experience,
+                 r.workLocation, r.latitude, r.longitude
+        HAVING (:#{#cond.techStacks} IS NULL OR COUNT(DISTINCT ts.id) = :#{#cond.techStackCount}) AND
+               (:#{#cond.tags} IS NULL OR COUNT(DISTINCT t.id) = :#{#cond.tagCount})
+    """)
+    List<RecruitmentResponseDTO> findBySearchConditions(@Param("cond") RecruitmentSearchConditionDTO cond);
+
 }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
@@ -1,0 +1,54 @@
+package org.example.hugmeexp.domain.recruitment.repository;
+
+import org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO;
+import org.example.hugmeexp.domain.recruitment.entity.Recruitment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Repository
+public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> {
+
+    @Query("SELECT new org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO( " +
+            "r.id, r.title, c.companyName, c.companyImageUrl, r.dueDate, r.experience, " +
+            "r.workLocation, r.latitude, r.longitude " +
+            ") " +
+            "FROM Recruitment r " +
+            "JOIN r.company c " +
+            "LEFT JOIN r.techStacks ts " +
+            "LEFT JOIN r.tags t " +
+            "WHERE (:salaryMin IS NULL OR r.salaryMin >= :salaryMin) AND " +
+                    "(:salaryMax IS NULL OR r.salaryMax <= :salaryMax) AND " +
+                    "(:experience IS NULL OR r.experience = :experience) AND " +
+                    "(:education IS NULL OR r.education = :education) AND " +
+                    "(:workLocation IS NULL OR r.workLocation LIKE %:workLocation%) AND " +
+                    "(:topLeftLat IS NULL OR r.latitude >= :topLeftLat) AND " +
+                    "(:topLeftLng IS NULL OR r.longitude <= :topLeftLng) AND " +
+                    "(:bottomRightLat IS NULL OR r.latitude <= :bottomRightLat) AND " +
+                    "(:bottomRightLng IS NULL OR r.longitude >= :bottomRightLng) AND " +
+                    "(:techStacks IS NULL OR ts.id IN :techStacks) AND " +
+                    "(:tags IS NULL OR t.id IN :tags) " +
+            "GROUP BY r.id, r.title, c.companyName, c.companyImageUrl, r.dueDate, r.experience, " +
+                        "r.workLocation, r.latitude, r.longitude " +
+            "HAVING (:techStacks IS NULL OR COUNT(DISTINCT ts.id) = :techStackCount) AND " +
+                    "(:tags IS NULL OR COUNT(DISTINCT t.id) = :tagCount)")
+    List<RecruitmentResponseDTO> findBySearchConditions(
+            Integer salaryMin,
+            Integer salaryMax,
+            Integer experience,
+            Integer education,
+            String workLocation,
+            BigDecimal topLeftLat,
+            BigDecimal topLeftLng,
+            BigDecimal bottomRightLat,
+            BigDecimal bottomRightLng,
+            List<Long> techStacks,
+            List<Long> tags,
+            @Param("techStackCount") Long techStackCount,
+            @Param("tagCount") Long tagCount
+    );
+}

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
@@ -31,8 +31,8 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
               (:#{#cond.topLeftLng} IS NULL OR r.longitude >= :#{#cond.topLeftLng}) AND
               (:#{#cond.bottomRightLat} IS NULL OR r.latitude <= :#{#cond.bottomRightLat}) AND
               (:#{#cond.bottomRightLng} IS NULL OR r.longitude <= :#{#cond.bottomRightLng}) AND
-              (:#{#cond.techStacks} IS NULL OR ts.id IN :#{#cond.techStacks}) AND
-              (:#{#cond.tags} IS NULL OR t.id IN :#{#cond.tags})
+              (:#{#cond.techStacks == null or #cond.techStacks.isEmpty()} OR ts.id IN :#{#cond.techStacks}) AND
+              (:#{#cond.tags == null or #cond.tags.isEmpty()} OR t.id IN :#{#cond.tags})
         GROUP BY r.id, r.title, c.companyName, c.companyImageUrl, r.dueDate, r.experience,
                  r.workLocation, r.latitude, r.longitude
         HAVING (:#{#cond.techStacks} IS NULL OR COUNT(DISTINCT ts.id) = :#{#cond.techStackCount}) AND

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
@@ -19,10 +19,11 @@ public class RecruitmentService {
     private final RecruitmentRepository recruitmentRepository;
 
     public List<RecruitmentResponseDTO> listRecruitments(RecruitmentSearchConditionDTO cond) {
-
         RecruitmentSearchConditionDTO enrichedCond = cond.toBuilder()
-                .techStackCount(cond.getTechStacks() == null ? null : (long) cond.getTechStacks().size())
-                .tagCount(cond.getTags() == null ? null : (long) cond.getTags().size())
+                .techStacks((cond.getTechStacks() == null || cond.getTechStacks().isEmpty()) ? null : cond.getTechStacks())
+                .tags((cond.getTags() == null || cond.getTags().isEmpty()) ? null : cond.getTags())
+                .techStackCount((cond.getTechStacks() == null) ? null : (long) cond.getTechStacks().size())
+                .tagCount((cond.getTags() == null) ? null : (long) cond.getTags().size())
                 .build();
 
         return recruitmentRepository.findBySearchConditions(enrichedCond);

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
@@ -22,8 +22,8 @@ public class RecruitmentService {
         RecruitmentSearchConditionDTO enrichedCond = cond.toBuilder()
                 .techStacks((cond.getTechStacks() == null || cond.getTechStacks().isEmpty()) ? null : cond.getTechStacks())
                 .tags((cond.getTags() == null || cond.getTags().isEmpty()) ? null : cond.getTags())
-                .techStackCount((cond.getTechStacks() == null) ? null : (long) cond.getTechStacks().size())
-                .tagCount((cond.getTags() == null) ? null : (long) cond.getTags().size())
+                .techStackCount((cond.getTechStacks() == null || cond.getTechStacks().isEmpty()) ? null : (long) cond.getTechStacks().size())
+                .tagCount((cond.getTags() == null || cond.getTags().isEmpty()) ? null : (long) cond.getTags().size())
                 .build();
 
         return recruitmentRepository.findBySearchConditions(enrichedCond);

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
@@ -1,0 +1,43 @@
+package org.example.hugmeexp.domain.recruitment.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO;
+import org.example.hugmeexp.domain.recruitment.dto.RecruitmentSearchConditionDTO;
+import org.example.hugmeexp.domain.recruitment.repository.RecruitmentRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RecruitmentService {
+
+    private final RecruitmentRepository recruitmentRepository;
+
+    public List<RecruitmentResponseDTO> listRecruitments(RecruitmentSearchConditionDTO cond) {
+
+        List<Long> techStacks = cond.getTechStacks();
+        List<Long> tags = cond.getTags();
+
+        Long techStackCount = (techStacks == null) ? null : (long) techStacks.size();
+        Long tagCount = (tags == null) ? null : (long) tags.size();
+
+        return recruitmentRepository.findBySearchConditions(
+                cond.getSalaryMin(),
+                cond.getSalaryMax(),
+                cond.getExperience(),
+                cond.getEducation(),
+                cond.getWorkLocation(),
+                cond.getTopLeftLat(),
+                cond.getTopLeftLng(),
+                cond.getBottomRightLat(),
+                cond.getBottomRightLng(),
+                techStacks,
+                tags,
+                techStackCount,
+                tagCount
+        );
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
@@ -6,38 +6,25 @@ import org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentSearchConditionDTO;
 import org.example.hugmeexp.domain.recruitment.repository.RecruitmentRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class RecruitmentService {
 
     private final RecruitmentRepository recruitmentRepository;
 
     public List<RecruitmentResponseDTO> listRecruitments(RecruitmentSearchConditionDTO cond) {
 
-        List<Long> techStacks = cond.getTechStacks();
-        List<Long> tags = cond.getTags();
+        RecruitmentSearchConditionDTO enrichedCond = cond.toBuilder()
+                .techStackCount(cond.getTechStacks() == null ? null : (long) cond.getTechStacks().size())
+                .tagCount(cond.getTags() == null ? null : (long) cond.getTags().size())
+                .build();
 
-        Long techStackCount = (techStacks == null) ? null : (long) techStacks.size();
-        Long tagCount = (tags == null) ? null : (long) tags.size();
-
-        return recruitmentRepository.findBySearchConditions(
-                cond.getSalaryMin(),
-                cond.getSalaryMax(),
-                cond.getExperience(),
-                cond.getEducation(),
-                cond.getWorkLocation(),
-                cond.getTopLeftLat(),
-                cond.getTopLeftLng(),
-                cond.getBottomRightLat(),
-                cond.getBottomRightLng(),
-                techStacks,
-                tags,
-                techStackCount,
-                tagCount
-        );
+        return recruitmentRepository.findBySearchConditions(enrichedCond);
     }
 }

--- a/src/test/http/recruitment.http
+++ b/src/test/http/recruitment.http
@@ -1,0 +1,37 @@
+@host = localhost
+@port = 8080
+@baseUrl = http://{{host}}:{{port}}/api
+
+### 🔐 로그인 - accessToken 저장
+POST {{baseUrl}}/login
+Content-Type: application/json
+
+{
+  "username": "test01",
+  "password": "123456789"
+}
+
+> {%
+    const accessToken = response.body.data.accessToken;
+    client.global.set("accessToken", accessToken);
+%}
+
+### 📄 채용 공고 전체 조회
+GET {{baseUrl}}/recruitments
+Authorization: Bearer {{accessToken}}
+
+### 🔍 조건 검색 - 경력 2년 이상, 대졸 이상, 서울, 최소 연봉 3000
+GET {{baseUrl}}/recruitments?experience=2&education=30&workLocation=강남&salaryMin=3000
+Authorization: Bearer {{accessToken}}
+
+### 🗺️ 지도 기반 조회 - 좌표 설정 포함
+GET {{baseUrl}}/recruitments?topLeftLat=37.60&topLeftLng=126.90&bottomRightLat=37.30&bottomRightLng=127.10
+Authorization: Bearer {{accessToken}}
+
+### 🧪 기술 스택 + 태그 검색 (복수 선택 시)
+GET {{baseUrl}}/recruitments?techStacks=1&techStacks=2&tags=3&tags=4
+Authorization: Bearer {{accessToken}}
+
+### 🧾 복합 검색 예시
+GET {{baseUrl}}/recruitments?experience=1&education=20&salaryMin=2500&workLocation=강남&techStacks=1&techStacks=2&tags=5&tags=6
+Authorization: Bearer {{accessToken}}

--- a/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
@@ -48,26 +48,14 @@ public class RecruitmentServiceTest {
                 .build();
 
         List<RecruitmentResponseDTO> expectedResult = createMockResponseList();
-        when(recruitmentRepository.findBySearchConditions(
-                eq(3000), eq(5000), eq(3), eq(4), eq("서울"),
-                eq(new BigDecimal("37.5")), eq(new BigDecimal("126.9")),
-                eq(new BigDecimal("37.4")), eq(new BigDecimal("127.0")),
-                eq(List.of(1L, 2L)), eq(List.of(3L, 4L)),
-                eq(2L), eq(2L)
-        )).thenReturn(expectedResult);
+        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class))).thenReturn(expectedResult);
 
         // When
         List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition);
 
         // Then
         assertEquals(expectedResult, result);
-        verify(recruitmentRepository).findBySearchConditions(
-                eq(3000), eq(5000), eq(3), eq(4), eq("서울"),
-                eq(new BigDecimal("37.5")), eq(new BigDecimal("126.9")),
-                eq(new BigDecimal("37.4")), eq(new BigDecimal("127.0")),
-                eq(List.of(1L, 2L)), eq(List.of(3L, 4L)),
-                eq(2L), eq(2L)
-        );
+        verify(recruitmentRepository).findBySearchConditions(any(RecruitmentSearchConditionDTO.class));
     }
 
     @Test
@@ -77,22 +65,14 @@ public class RecruitmentServiceTest {
         RecruitmentSearchConditionDTO condition = RecruitmentSearchConditionDTO.builder().build();
 
         List<RecruitmentResponseDTO> expectedResult = createMockResponseList();
-        when(recruitmentRepository.findBySearchConditions(
-                isNull(), isNull(), isNull(), isNull(), isNull(),
-                isNull(), isNull(), isNull(), isNull(),
-                isNull(), isNull(), isNull(), isNull()
-        )).thenReturn(expectedResult);
+        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class))).thenReturn(expectedResult);
 
         // When
         List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition);
 
         // Then
         assertEquals(expectedResult, result);
-        verify(recruitmentRepository).findBySearchConditions(
-                isNull(), isNull(), isNull(), isNull(), isNull(),
-                isNull(), isNull(), isNull(), isNull(),
-                isNull(), isNull(), isNull(), isNull()
-        );
+        verify(recruitmentRepository).findBySearchConditions(any(RecruitmentSearchConditionDTO.class));
     }
 
     @Test
@@ -105,22 +85,14 @@ public class RecruitmentServiceTest {
                 .build();
 
         List<RecruitmentResponseDTO> expectedResult = createMockResponseList();
-        when(recruitmentRepository.findBySearchConditions(
-                eq(3000), eq(5000), isNull(), isNull(), isNull(),
-                isNull(), isNull(), isNull(), isNull(),
-                isNull(), isNull(), isNull(), isNull()
-        )).thenReturn(expectedResult);
+        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class))).thenReturn(expectedResult);
 
         // When
         List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition);
 
         // Then
         assertEquals(expectedResult, result);
-        verify(recruitmentRepository).findBySearchConditions(
-                eq(3000), eq(5000), isNull(), isNull(), isNull(),
-                isNull(), isNull(), isNull(), isNull(),
-                isNull(), isNull(), isNull(), isNull()
-        );
+        verify(recruitmentRepository).findBySearchConditions(any(RecruitmentSearchConditionDTO.class));
     }
 
     @Test
@@ -135,22 +107,14 @@ public class RecruitmentServiceTest {
                 .build();
 
         List<RecruitmentResponseDTO> expectedResult = createMockResponseList();
-        when(recruitmentRepository.findBySearchConditions(
-                eq(3000), eq(5000), isNull(), isNull(), isNull(),
-                isNull(), isNull(), isNull(), isNull(),
-                isNull(), isNull(), isNull(), isNull()
-        )).thenReturn(expectedResult);
+        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class))).thenReturn(expectedResult);
 
         // When
         List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition);
 
         // Then
         assertEquals(expectedResult, result);
-        verify(recruitmentRepository).findBySearchConditions(
-                eq(3000), eq(5000), isNull(), isNull(), isNull(),
-                isNull(), isNull(), isNull(), isNull(),
-                isNull(), isNull(), isNull(), isNull()
-        );
+        verify(recruitmentRepository).findBySearchConditions(any(RecruitmentSearchConditionDTO.class));
     }
 
     @Test
@@ -163,22 +127,14 @@ public class RecruitmentServiceTest {
                 .build();
 
         List<RecruitmentResponseDTO> expectedResult = createMockResponseList();
-        when(recruitmentRepository.findBySearchConditions(
-                isNull(), isNull(), isNull(), isNull(), isNull(),
-                isNull(), isNull(), isNull(), isNull(),
-                eq(List.of()), eq(List.of()), eq(0L), eq(0L)
-        )).thenReturn(expectedResult);
+        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class))).thenReturn(expectedResult);
 
         // When
         List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition);
 
         // Then
         assertEquals(expectedResult, result);
-        verify(recruitmentRepository).findBySearchConditions(
-                isNull(), isNull(), isNull(), isNull(), isNull(),
-                isNull(), isNull(), isNull(), isNull(),
-                eq(List.of()), eq(List.of()), eq(0L), eq(0L)
-        );
+        verify(recruitmentRepository).findBySearchConditions(any(RecruitmentSearchConditionDTO.class));
     }
 
     @Test
@@ -191,22 +147,14 @@ public class RecruitmentServiceTest {
                 .build();
 
         List<RecruitmentResponseDTO> expectedResult = createMockResponseList();
-        when(recruitmentRepository.findBySearchConditions(
-                isNull(), isNull(), isNull(), isNull(), isNull(),
-                isNull(), isNull(), isNull(), isNull(),
-                eq(List.of(1L, 2L, 3L)), isNull(), eq(3L), isNull()
-        )).thenReturn(expectedResult);
+        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class))).thenReturn(expectedResult);
 
         // When
         List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition);
 
         // Then
         assertEquals(expectedResult, result);
-        verify(recruitmentRepository).findBySearchConditions(
-                isNull(), isNull(), isNull(), isNull(), isNull(),
-                isNull(), isNull(), isNull(), isNull(),
-                eq(List.of(1L, 2L, 3L)), isNull(), eq(3L), isNull()
-        );
+        verify(recruitmentRepository).findBySearchConditions(any(RecruitmentSearchConditionDTO.class));
     }
 
     @Test
@@ -219,42 +167,34 @@ public class RecruitmentServiceTest {
                 .build();
 
         List<RecruitmentResponseDTO> expectedResult = createMockResponseList();
-        when(recruitmentRepository.findBySearchConditions(
-                isNull(), isNull(), isNull(), isNull(), isNull(),
-                isNull(), isNull(), isNull(), isNull(),
-                isNull(), eq(List.of(1L, 2L)), isNull(), eq(2L)
-        )).thenReturn(expectedResult);
+        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class))).thenReturn(expectedResult);
 
         // When
         List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition);
 
         // Then
         assertEquals(expectedResult, result);
-        verify(recruitmentRepository).findBySearchConditions(
-                isNull(), isNull(), isNull(), isNull(), isNull(),
-                isNull(), isNull(), isNull(), isNull(),
-                isNull(), eq(List.of(1L, 2L)), isNull(), eq(2L)
-        );
+        verify(recruitmentRepository).findBySearchConditions(any(RecruitmentSearchConditionDTO.class));
     }
 
     // 테스트용 응답 DTO 리스트 생성 헬퍼 메소드
     private List<RecruitmentResponseDTO> createMockResponseList() {
         List<RecruitmentResponseDTO> responses = new ArrayList<>();
-        
+
         // 첫 번째 응답 DTO
         responses.add(new RecruitmentResponseDTO(
                 1L, "백엔드 개발자 모집", "ABC 회사", "company_image_url_1.jpg",
                 LocalDateTime.of(2023, 12, 31, 23, 59),
                 3, "서울시 강남구", new BigDecimal("37.5"), new BigDecimal("127.0")
         ));
-        
+
         // 두 번째 응답 DTO
         responses.add(new RecruitmentResponseDTO(
                 2L, "프론트엔드 개발자 모집", "XYZ 회사", "company_image_url_2.jpg",
                 LocalDateTime.of(2023, 11, 30, 23, 59),
                 2, "서울시 서초구", new BigDecimal("37.4"), new BigDecimal("127.1")
         ));
-        
+
         return responses;
     }
 }

--- a/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
@@ -1,0 +1,260 @@
+package org.example.hugmeexp.domain.recruitment.service;
+
+import org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO;
+import org.example.hugmeexp.domain.recruitment.dto.RecruitmentSearchConditionDTO;
+import org.example.hugmeexp.domain.recruitment.repository.RecruitmentRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class RecruitmentServiceTest {
+
+    @Mock
+    private RecruitmentRepository recruitmentRepository;
+
+    @InjectMocks
+    private RecruitmentService recruitmentService;
+
+    @Test
+    @DisplayName("모든 파라미터가 제공된 경우 테스트")
+    void listRecruitments_AllParamsProvided_ShouldCallRepositoryWithCorrectParams() {
+        // Given
+        RecruitmentSearchConditionDTO condition = RecruitmentSearchConditionDTO.builder()
+                .salaryMin(3000)
+                .salaryMax(5000)
+                .experience(3)
+                .education(4)
+                .workLocation("서울")
+                .techStacks(List.of(1L, 2L))
+                .tags(List.of(3L, 4L))
+                .topLeftLat(new BigDecimal("37.5"))
+                .topLeftLng(new BigDecimal("126.9"))
+                .bottomRightLat(new BigDecimal("37.4"))
+                .bottomRightLng(new BigDecimal("127.0"))
+                .build();
+
+        List<RecruitmentResponseDTO> expectedResult = createMockResponseList();
+        when(recruitmentRepository.findBySearchConditions(
+                eq(3000), eq(5000), eq(3), eq(4), eq("서울"),
+                eq(new BigDecimal("37.5")), eq(new BigDecimal("126.9")),
+                eq(new BigDecimal("37.4")), eq(new BigDecimal("127.0")),
+                eq(List.of(1L, 2L)), eq(List.of(3L, 4L)),
+                eq(2L), eq(2L)
+        )).thenReturn(expectedResult);
+
+        // When
+        List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition);
+
+        // Then
+        assertEquals(expectedResult, result);
+        verify(recruitmentRepository).findBySearchConditions(
+                eq(3000), eq(5000), eq(3), eq(4), eq("서울"),
+                eq(new BigDecimal("37.5")), eq(new BigDecimal("126.9")),
+                eq(new BigDecimal("37.4")), eq(new BigDecimal("127.0")),
+                eq(List.of(1L, 2L)), eq(List.of(3L, 4L)),
+                eq(2L), eq(2L)
+        );
+    }
+
+    @Test
+    @DisplayName("파라미터가 없는 경우 테스트")
+    void listRecruitments_NoParams_ShouldPassNullValues() {
+        // Given
+        RecruitmentSearchConditionDTO condition = RecruitmentSearchConditionDTO.builder().build();
+
+        List<RecruitmentResponseDTO> expectedResult = createMockResponseList();
+        when(recruitmentRepository.findBySearchConditions(
+                isNull(), isNull(), isNull(), isNull(), isNull(),
+                isNull(), isNull(), isNull(), isNull(),
+                isNull(), isNull(), isNull(), isNull()
+        )).thenReturn(expectedResult);
+
+        // When
+        List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition);
+
+        // Then
+        assertEquals(expectedResult, result);
+        verify(recruitmentRepository).findBySearchConditions(
+                isNull(), isNull(), isNull(), isNull(), isNull(),
+                isNull(), isNull(), isNull(), isNull(),
+                isNull(), isNull(), isNull(), isNull()
+        );
+    }
+
+    @Test
+    @DisplayName("일부 파라미터만 제공된 경우 테스트")
+    void listRecruitments_SomeParams_ShouldPassCorrectValues() {
+        // Given
+        RecruitmentSearchConditionDTO condition = RecruitmentSearchConditionDTO.builder()
+                .salaryMin(3000)
+                .salaryMax(5000)
+                .build();
+
+        List<RecruitmentResponseDTO> expectedResult = createMockResponseList();
+        when(recruitmentRepository.findBySearchConditions(
+                eq(3000), eq(5000), isNull(), isNull(), isNull(),
+                isNull(), isNull(), isNull(), isNull(),
+                isNull(), isNull(), isNull(), isNull()
+        )).thenReturn(expectedResult);
+
+        // When
+        List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition);
+
+        // Then
+        assertEquals(expectedResult, result);
+        verify(recruitmentRepository).findBySearchConditions(
+                eq(3000), eq(5000), isNull(), isNull(), isNull(),
+                isNull(), isNull(), isNull(), isNull(),
+                isNull(), isNull(), isNull(), isNull()
+        );
+    }
+
+    @Test
+    @DisplayName("techStacks와 tags가 null인 경우 테스트")
+    void listRecruitments_NullTechStacksAndTags_ShouldPassNullCounts() {
+        // Given
+        RecruitmentSearchConditionDTO condition = RecruitmentSearchConditionDTO.builder()
+                .salaryMin(3000)
+                .salaryMax(5000)
+                .techStacks(null)
+                .tags(null)
+                .build();
+
+        List<RecruitmentResponseDTO> expectedResult = createMockResponseList();
+        when(recruitmentRepository.findBySearchConditions(
+                eq(3000), eq(5000), isNull(), isNull(), isNull(),
+                isNull(), isNull(), isNull(), isNull(),
+                isNull(), isNull(), isNull(), isNull()
+        )).thenReturn(expectedResult);
+
+        // When
+        List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition);
+
+        // Then
+        assertEquals(expectedResult, result);
+        verify(recruitmentRepository).findBySearchConditions(
+                eq(3000), eq(5000), isNull(), isNull(), isNull(),
+                isNull(), isNull(), isNull(), isNull(),
+                isNull(), isNull(), isNull(), isNull()
+        );
+    }
+
+    @Test
+    @DisplayName("techStacks와 tags가 빈 리스트인 경우 테스트")
+    void listRecruitments_EmptyTechStacksAndTags_ShouldPassZeroCounts() {
+        // Given
+        RecruitmentSearchConditionDTO condition = RecruitmentSearchConditionDTO.builder()
+                .techStacks(List.of())
+                .tags(List.of())
+                .build();
+
+        List<RecruitmentResponseDTO> expectedResult = createMockResponseList();
+        when(recruitmentRepository.findBySearchConditions(
+                isNull(), isNull(), isNull(), isNull(), isNull(),
+                isNull(), isNull(), isNull(), isNull(),
+                eq(List.of()), eq(List.of()), eq(0L), eq(0L)
+        )).thenReturn(expectedResult);
+
+        // When
+        List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition);
+
+        // Then
+        assertEquals(expectedResult, result);
+        verify(recruitmentRepository).findBySearchConditions(
+                isNull(), isNull(), isNull(), isNull(), isNull(),
+                isNull(), isNull(), isNull(), isNull(),
+                eq(List.of()), eq(List.of()), eq(0L), eq(0L)
+        );
+    }
+
+    @Test
+    @DisplayName("techStacks는 있고 tags는 null인 경우 테스트")
+    void listRecruitments_WithTechStacksNullTags_ShouldPassCorrectCounts() {
+        // Given
+        RecruitmentSearchConditionDTO condition = RecruitmentSearchConditionDTO.builder()
+                .techStacks(List.of(1L, 2L, 3L))
+                .tags(null)
+                .build();
+
+        List<RecruitmentResponseDTO> expectedResult = createMockResponseList();
+        when(recruitmentRepository.findBySearchConditions(
+                isNull(), isNull(), isNull(), isNull(), isNull(),
+                isNull(), isNull(), isNull(), isNull(),
+                eq(List.of(1L, 2L, 3L)), isNull(), eq(3L), isNull()
+        )).thenReturn(expectedResult);
+
+        // When
+        List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition);
+
+        // Then
+        assertEquals(expectedResult, result);
+        verify(recruitmentRepository).findBySearchConditions(
+                isNull(), isNull(), isNull(), isNull(), isNull(),
+                isNull(), isNull(), isNull(), isNull(),
+                eq(List.of(1L, 2L, 3L)), isNull(), eq(3L), isNull()
+        );
+    }
+
+    @Test
+    @DisplayName("techStacks는 null이고 tags는 있는 경우 테스트")
+    void listRecruitments_NullTechStacksWithTags_ShouldPassCorrectCounts() {
+        // Given
+        RecruitmentSearchConditionDTO condition = RecruitmentSearchConditionDTO.builder()
+                .techStacks(null)
+                .tags(List.of(1L, 2L))
+                .build();
+
+        List<RecruitmentResponseDTO> expectedResult = createMockResponseList();
+        when(recruitmentRepository.findBySearchConditions(
+                isNull(), isNull(), isNull(), isNull(), isNull(),
+                isNull(), isNull(), isNull(), isNull(),
+                isNull(), eq(List.of(1L, 2L)), isNull(), eq(2L)
+        )).thenReturn(expectedResult);
+
+        // When
+        List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition);
+
+        // Then
+        assertEquals(expectedResult, result);
+        verify(recruitmentRepository).findBySearchConditions(
+                isNull(), isNull(), isNull(), isNull(), isNull(),
+                isNull(), isNull(), isNull(), isNull(),
+                isNull(), eq(List.of(1L, 2L)), isNull(), eq(2L)
+        );
+    }
+
+    // 테스트용 응답 DTO 리스트 생성 헬퍼 메소드
+    private List<RecruitmentResponseDTO> createMockResponseList() {
+        List<RecruitmentResponseDTO> responses = new ArrayList<>();
+        
+        // 첫 번째 응답 DTO
+        responses.add(new RecruitmentResponseDTO(
+                1L, "백엔드 개발자 모집", "ABC 회사", "company_image_url_1.jpg",
+                LocalDateTime.of(2023, 12, 31, 23, 59),
+                3, "서울시 강남구", new BigDecimal("37.5"), new BigDecimal("127.0")
+        ));
+        
+        // 두 번째 응답 DTO
+        responses.add(new RecruitmentResponseDTO(
+                2L, "프론트엔드 개발자 모집", "XYZ 회사", "company_image_url_2.jpg",
+                LocalDateTime.of(2023, 11, 30, 23, 59),
+                2, "서울시 서초구", new BigDecimal("37.4"), new BigDecimal("127.1")
+        ));
+        
+        return responses;
+    }
+}

--- a/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
@@ -55,7 +55,10 @@ public class RecruitmentServiceTest {
 
         // Then
         assertEquals(expectedResult, result);
-        verify(recruitmentRepository).findBySearchConditions(any(RecruitmentSearchConditionDTO.class));
+        verify(recruitmentRepository).findBySearchConditions(argThat(cond ->
+            cond.getTechStackCount() == 2L &&
+            cond.getTagCount() == 2L
+        ));
     }
 
     @Test

--- a/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
@@ -117,7 +117,10 @@ public class RecruitmentServiceTest {
 
         // Then
         assertEquals(expectedResult, result);
-        verify(recruitmentRepository).findBySearchConditions(any(RecruitmentSearchConditionDTO.class));
+        verify(recruitmentRepository).findBySearchConditions(argThat(cond ->
+            cond.getTechStackCount() == null &&
+            cond.getTagCount() == null
+        ));
     }
 
     @Test
@@ -137,7 +140,10 @@ public class RecruitmentServiceTest {
 
         // Then
         assertEquals(expectedResult, result);
-        verify(recruitmentRepository).findBySearchConditions(any(RecruitmentSearchConditionDTO.class));
+        verify(recruitmentRepository).findBySearchConditions(argThat(cond ->
+            cond.getTechStackCount() == null &&
+            cond.getTagCount() == null
+        ));
     }
 
     @Test


### PR DESCRIPTION
# 🚀 What’s this PR about?

- 채용 공고 리스트 조회 기능을 구현했습니다. 사용자가 채용 필터 조건을 입력하면 조건에 맞는 공고를 리스트로 조회할 수 있습니다.

# 🛠️ What’s been done?

- Recruitment, Company, TechStack, TechItem, Tag, TagItem 등 채용 관련 엔티티 및 테이블 설계
- RecruitmentService, RecruitmentController 작성
- GET /api/recruitments 요청으로 채용 공고 조회
- RecruitmentSearchConditionDTO로 필터 조건 전달받고, 동적 조건 검색 기능 구현 (현재는 JPA 기준)

# 🧪 Testing Details

- 모든 파라미터가 제공된 경우 테스트
- 파라미터가 없는 경우 테스트
- salaryMin, salaryMax만 주어진 경우 처리 확인
- techStacks, tags가 null일 때 count가 null로 처리되는지 검증
- techStacks, tags가 빈 리스트일 경우 count가 0L로 전달되는지 검증
- techStacks만 존재할 때 해당 리스트 및 count 처리 확인
- tags만 존재할 때 해당 리스트 및 count 처리 확인

# 👀 Checkpoints for Reviewers


# 📚 References & Resources

- **참고 자료:** 작업 중 참고한 문서, 코드 스니펫, 블로그, 사이트 등을 링크로 연결해 주세요.
  - 예: 공식 문서, 유용한 Stack Overflow 답변, 팀 내 참고 자료

# 🎯 Related Issues
- close#24 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 채용 공고 목록 조회 REST API가 추가되어 연봉, 경력, 학력, 기술 스택, 태그, 위치, 좌표 범위 등 다양한 조건으로 검색할 수 있습니다.
  * 채용 공고, 회사, 기술 스택, 태그, 기술 항목, 태그 항목 등 관련 데이터 모델이 새롭게 도입되었습니다.

* **테스트**
  * 채용 서비스 검색 기능에 대한 단위 테스트와 다양한 검색 조건을 검증하는 HTTP 테스트 스크립트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->