### PR TITLE
채용 기업 키워드 검색 기능 추가

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/controller/RecruitmentController.java
@@ -5,16 +5,15 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.hugmeexp.domain.recruitment.dto.RecruitmentCompanySearchResponseDTO;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentSearchConditionDTO;
+import org.example.hugmeexp.domain.recruitment.service.CompanyService;
 import org.example.hugmeexp.domain.recruitment.service.RecruitmentService;
 import org.example.hugmeexp.global.common.response.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -26,6 +25,7 @@ import java.util.List;
 public class RecruitmentController {
 
     private final RecruitmentService recruitmentService;
+    private final CompanyService companyService;
 
     @Operation(summary = "채용 공고 목록 조회", description = "채용 공고 목록을 조회합니다")
     @GetMapping
@@ -38,6 +38,26 @@ public class RecruitmentController {
                 .message("채용 공고 목록 조회 성공")
                 .data(result)
                 .build();
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @Operation(summary = "채용 기업 목록 조회", description = "채용 기업 목록을 조회합니다")
+    @GetMapping("/companies")
+    public ResponseEntity<Response<List<RecruitmentCompanySearchResponseDTO>>> searchCompanies(
+            @RequestParam(required = false) String keyword
+    ){
+
+        List<RecruitmentCompanySearchResponseDTO> result = companyService.searchCompaniesByKeyword(keyword);
+
+        Response<List<RecruitmentCompanySearchResponseDTO>> response = Response.<List<RecruitmentCompanySearchResponseDTO>>builder()
+                .message("기업 목록 조회 성공")
+                .data(result)
+                .build();
+
+        if(result.isEmpty()){
+            return ResponseEntity.noContent().build();
+        }
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/controller/RecruitmentController.java
@@ -50,14 +50,14 @@ public class RecruitmentController {
 
         List<RecruitmentCompanySearchResponseDTO> result = companyService.searchCompaniesByKeyword(keyword);
 
+        if(result.isEmpty()){
+            return ResponseEntity.noContent().build();
+        }
+
         Response<List<RecruitmentCompanySearchResponseDTO>> response = Response.<List<RecruitmentCompanySearchResponseDTO>>builder()
                 .message("기업 목록 조회 성공")
                 .data(result)
                 .build();
-
-        if(result.isEmpty()){
-            return ResponseEntity.noContent().build();
-        }
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentCompanySearchResponseDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentCompanySearchResponseDTO.java
@@ -1,0 +1,25 @@
+package org.example.hugmeexp.domain.recruitment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.hugmeexp.domain.recruitment.entity.Company;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+public class RecruitmentCompanySearchResponseDTO {
+
+    Long companyId;
+    String companyName;
+
+    public static RecruitmentCompanySearchResponseDTO from(Company company) {
+        return RecruitmentCompanySearchResponseDTO.builder()
+                .companyId(company.getId())
+                .companyName(company.getCompanyName())
+                .build();
+    }
+
+}

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentCompanySearchResponseDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentCompanySearchResponseDTO.java
@@ -12,8 +12,8 @@ import org.example.hugmeexp.domain.recruitment.entity.Company;
 @Builder(toBuilder = true)
 public class RecruitmentCompanySearchResponseDTO {
 
-    Long companyId;
-    String companyName;
+    private Long companyId;
+    private String companyName;
 
     public static RecruitmentCompanySearchResponseDTO from(Company company) {
         return RecruitmentCompanySearchResponseDTO.builder()

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/repository/CompanyRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/repository/CompanyRepository.java
@@ -1,0 +1,13 @@
+package org.example.hugmeexp.domain.recruitment.repository;
+
+import org.example.hugmeexp.domain.recruitment.entity.Company;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CompanyRepository extends JpaRepository<Company, Long> {
+
+    List<Company> findByCompanyNameContainingIgnoreCase(String companyName);
+}

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/service/CompanyService.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/service/CompanyService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentCompanySearchResponseDTO;
 import org.example.hugmeexp.domain.recruitment.entity.Company;
 import org.example.hugmeexp.domain.recruitment.repository.CompanyRepository;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,9 +27,12 @@ public class CompanyService {
      * @return 기업 목록 DTO
      */
     public List<RecruitmentCompanySearchResponseDTO> searchCompaniesByKeyword(String keyword) {
-        List<Company> companies = (keyword == null || keyword.isBlank())
-                ? companyRepository.findAll()
-                : companyRepository.findByCompanyNameContainingIgnoreCase(keyword);
+        List<Company> companies;
+        if (keyword == null || keyword.isBlank()) {
+            companies = companyRepository.findAll(PageRequest.of(0, 30)).getContent();
+        } else {
+            companies = companyRepository.findByCompanyNameContainingIgnoreCase(keyword);
+        }
 
         return companies.stream()
                 .map(RecruitmentCompanySearchResponseDTO::from)

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/service/CompanyService.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/service/CompanyService.java
@@ -3,7 +3,6 @@ package org.example.hugmeexp.domain.recruitment.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentCompanySearchResponseDTO;
-import org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO;
 import org.example.hugmeexp.domain.recruitment.entity.Company;
 import org.example.hugmeexp.domain.recruitment.repository.CompanyRepository;
 import org.springframework.stereotype.Service;
@@ -20,10 +19,11 @@ public class CompanyService {
     private final CompanyRepository companyRepository;
 
     /**
-     * 주어진 키워드로 기업 목록을 검색합니다.
+     * 기업 이름을 키워드로 검색하여 기업 목록을 조회합니다.
+     * 키워드가 null 또는 비어있으면 모든 기업을 조회합니다.
      *
-     * @param keyword 검색할 키워드
-     * @return 검색된 기업 목록
+     * @param keyword 검색 키워드
+     * @return 기업 목록 DTO
      */
     public List<RecruitmentCompanySearchResponseDTO> searchCompaniesByKeyword(String keyword) {
         List<Company> companies = (keyword == null || keyword.isBlank())

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/service/CompanyService.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/service/CompanyService.java
@@ -26,7 +26,9 @@ public class CompanyService {
      * @return 검색된 기업 목록
      */
     public List<RecruitmentCompanySearchResponseDTO> searchCompaniesByKeyword(String keyword) {
-        List<Company> companies = companyRepository.findByCompanyNameContainingIgnoreCase(keyword);
+        List<Company> companies = (keyword == null || keyword.isBlank())
+                ? companyRepository.findAll()
+                : companyRepository.findByCompanyNameContainingIgnoreCase(keyword);
 
         return companies.stream()
                 .map(RecruitmentCompanySearchResponseDTO::from)

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/service/CompanyService.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/service/CompanyService.java
@@ -1,0 +1,35 @@
+package org.example.hugmeexp.domain.recruitment.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.hugmeexp.domain.recruitment.dto.RecruitmentCompanySearchResponseDTO;
+import org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO;
+import org.example.hugmeexp.domain.recruitment.entity.Company;
+import org.example.hugmeexp.domain.recruitment.repository.CompanyRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CompanyService {
+
+    private final CompanyRepository companyRepository;
+
+    /**
+     * 주어진 키워드로 기업 목록을 검색합니다.
+     *
+     * @param keyword 검색할 키워드
+     * @return 검색된 기업 목록
+     */
+    public List<RecruitmentCompanySearchResponseDTO> searchCompaniesByKeyword(String keyword) {
+        List<Company> companies = companyRepository.findByCompanyNameContainingIgnoreCase(keyword);
+
+        return companies.stream()
+                .map(RecruitmentCompanySearchResponseDTO::from)
+                .toList();
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentSearchConditionDTO;
+import org.example.hugmeexp.domain.recruitment.entity.Company;
 import org.example.hugmeexp.domain.recruitment.repository.RecruitmentRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +19,13 @@ public class RecruitmentService {
 
     private final RecruitmentRepository recruitmentRepository;
 
+    /**
+     * 채용 공고 목록을 조회합니다.
+     * 검색 조건에 따라 필터링된 채용 공고 목록을 반환합니다.
+     *
+     * @param cond 검색 조건 DTO
+     * @return 채용 공고 목록
+     */
     public List<RecruitmentResponseDTO> listRecruitments(RecruitmentSearchConditionDTO cond) {
         RecruitmentSearchConditionDTO enrichedCond = cond.toBuilder()
                 .techStacks((cond.getTechStacks() == null || cond.getTechStacks().isEmpty()) ? null : cond.getTechStacks())

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentSearchConditionDTO;
-import org.example.hugmeexp.domain.recruitment.entity.Company;
 import org.example.hugmeexp.domain.recruitment.repository.RecruitmentRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/test/http/recruitment.http
+++ b/src/test/http/recruitment.http
@@ -35,3 +35,17 @@ Authorization: Bearer {{accessToken}}
 ### 🧾 복합 검색 예시
 GET {{baseUrl}}/recruitments?experience=1&education=20&salaryMin=2500&workLocation=강남&techStacks=1&techStacks=2&tags=5&tags=6
 Authorization: Bearer {{accessToken}}
+
+
+
+### 🏢 채용 기업 이름 검색 (예: 네이버)
+GET {{baseUrl}}/recruitments/companies?keyword=네이버
+Authorization: Bearer {{accessToken}}
+
+### 🏢 채용 기업 이름 검색 (없는 경우)
+GET {{baseUrl}}/recruitments/companies?keyword=없는회사
+Authorization: Bearer {{accessToken}}
+
+### ❌ 채용 기업 키워드 누락 (예외 테스트)
+GET {{baseUrl}}/recruitments/companies
+Authorization: Bearer {{accessToken}}

--- a/src/test/java/org/example/hugmeexp/domain/recruitment/service/CompanyServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/recruitment/service/CompanyServiceTest.java
@@ -122,6 +122,22 @@ public class CompanyServiceTest {
         verify(companyRepository).findByCompanyNameContainingIgnoreCase(keyword);
     }
 
+    @Test
+    @DisplayName("공백 키워드로 회사 검색")
+    void searchCompaniesByKeyword_WithBlankKeyword_ShouldReturnAllCompanies() {
+        // Given
+        String keyword = "   ";
+        List<Company> mockCompanies = createMockCompanies();
+        when(companyRepository.findAll(PageRequest.of(0, 30))).thenReturn(new PageImpl<>(mockCompanies));
+
+        // When
+        List<RecruitmentCompanySearchResponseDTO> result = companyService.searchCompaniesByKeyword(keyword);
+
+        // Then
+        assertEquals(2, result.size());
+        verify(companyRepository).findAll(PageRequest.of(0, 30));
+    }
+
     // 테스트용 회사 데이터 생성 헬퍼 메소드
     private List<Company> createMockCompanies() {
         List<Company> companies = new ArrayList<>();

--- a/src/test/java/org/example/hugmeexp/domain/recruitment/service/CompanyServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/recruitment/service/CompanyServiceTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -65,19 +67,43 @@ public class CompanyServiceTest {
     }
 
     @Test
-    @DisplayName("빈 키워드로 회사 검색")
+    @DisplayName("빈 키워드로 회사 검색 - 페이징 처리")
     void searchCompaniesByKeyword_WithEmptyKeyword_ShouldReturnAllCompanies() {
         // Given
         String keyword = "";
         List<Company> mockCompanies = createMockCompanies();
-        when(companyRepository.findAll()).thenReturn(mockCompanies);
+        when(companyRepository.findAll(PageRequest.of(0, 30))).thenReturn(new PageImpl<>(mockCompanies));
 
         // When
         List<RecruitmentCompanySearchResponseDTO> result = companyService.searchCompaniesByKeyword(keyword);
 
         // Then
         assertEquals(2, result.size());
-        verify(companyRepository).findAll();
+        assertEquals(1L, result.get(0).getCompanyId());
+        assertEquals("ABC 테크", result.get(0).getCompanyName());
+        assertEquals(2L, result.get(1).getCompanyId());
+        assertEquals("XYZ 테크놀로지", result.get(1).getCompanyName());
+        verify(companyRepository).findAll(PageRequest.of(0, 30));
+    }
+
+    @Test
+    @DisplayName("null 키워드로 회사 검색 - 페이징 처리")
+    void searchCompaniesByKeyword_WithNullKeyword_ShouldReturnAllCompanies() {
+        // Given
+        String keyword = null;
+        List<Company> mockCompanies = createMockCompanies();
+        when(companyRepository.findAll(PageRequest.of(0, 30))).thenReturn(new PageImpl<>(mockCompanies));
+
+        // When
+        List<RecruitmentCompanySearchResponseDTO> result = companyService.searchCompaniesByKeyword(keyword);
+
+        // Then
+        assertEquals(2, result.size());
+        assertEquals(1L, result.get(0).getCompanyId());
+        assertEquals("ABC 테크", result.get(0).getCompanyName());
+        assertEquals(2L, result.get(1).getCompanyId());
+        assertEquals("XYZ 테크놀로지", result.get(1).getCompanyName());
+        verify(companyRepository).findAll(PageRequest.of(0, 30));
     }
 
     @Test

--- a/src/test/java/org/example/hugmeexp/domain/recruitment/service/CompanyServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/recruitment/service/CompanyServiceTest.java
@@ -1,0 +1,129 @@
+package org.example.hugmeexp.domain.recruitment.service;
+
+import org.example.hugmeexp.domain.recruitment.dto.RecruitmentCompanySearchResponseDTO;
+import org.example.hugmeexp.domain.recruitment.entity.Company;
+import org.example.hugmeexp.domain.recruitment.repository.CompanyRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class CompanyServiceTest {
+
+    @Mock
+    private CompanyRepository companyRepository;
+
+    @InjectMocks
+    private CompanyService companyService;
+
+    @Test
+    @DisplayName("키워드로 회사 검색 - 결과가 있는 경우")
+    void searchCompaniesByKeyword_WithMatchingResults_ShouldReturnCompanies() {
+        // Given
+        String keyword = "테크";
+        List<Company> mockCompanies = createMockCompanies();
+        when(companyRepository.findByCompanyNameContainingIgnoreCase(keyword)).thenReturn(mockCompanies);
+
+        // When
+        List<RecruitmentCompanySearchResponseDTO> result = companyService.searchCompaniesByKeyword(keyword);
+
+        // Then
+        assertEquals(2, result.size());
+        assertEquals(1L, result.get(0).getCompanyId());
+        assertEquals("ABC 테크", result.get(0).getCompanyName());
+        assertEquals(2L, result.get(1).getCompanyId());
+        assertEquals("XYZ 테크놀로지", result.get(1).getCompanyName());
+        verify(companyRepository).findByCompanyNameContainingIgnoreCase(keyword);
+    }
+
+    @Test
+    @DisplayName("키워드로 회사 검색 - 결과가 없는 경우")
+    void searchCompaniesByKeyword_WithNoResults_ShouldReturnEmptyList() {
+        // Given
+        String keyword = "존재하지않는회사";
+        when(companyRepository.findByCompanyNameContainingIgnoreCase(keyword)).thenReturn(Collections.emptyList());
+
+        // When
+        List<RecruitmentCompanySearchResponseDTO> result = companyService.searchCompaniesByKeyword(keyword);
+
+        // Then
+        assertEquals(0, result.size());
+        verify(companyRepository).findByCompanyNameContainingIgnoreCase(keyword);
+    }
+
+    @Test
+    @DisplayName("빈 키워드로 회사 검색")
+    void searchCompaniesByKeyword_WithEmptyKeyword_ShouldReturnAllCompanies() {
+        // Given
+        String keyword = "";
+        List<Company> mockCompanies = createMockCompanies();
+        when(companyRepository.findAll()).thenReturn(mockCompanies);
+
+        // When
+        List<RecruitmentCompanySearchResponseDTO> result = companyService.searchCompaniesByKeyword(keyword);
+
+        // Then
+        assertEquals(2, result.size());
+        verify(companyRepository).findAll();
+    }
+
+    @Test
+    @DisplayName("대소문자 구분 없이 회사 검색")
+    void searchCompaniesByKeyword_CaseInsensitive_ShouldReturnMatchingCompanies() {
+        // Given
+        String keyword = "tEcH"; // 대소문자 혼합
+        List<Company> mockCompanies = createMockCompanies();
+        when(companyRepository.findByCompanyNameContainingIgnoreCase(keyword)).thenReturn(mockCompanies);
+
+        // When
+        List<RecruitmentCompanySearchResponseDTO> result = companyService.searchCompaniesByKeyword(keyword);
+
+        // Then
+        assertEquals(2, result.size());
+        verify(companyRepository).findByCompanyNameContainingIgnoreCase(keyword);
+    }
+
+    // 테스트용 회사 데이터 생성 헬퍼 메소드
+    private List<Company> createMockCompanies() {
+        List<Company> companies = new ArrayList<>();
+
+        // 첫 번째 회사
+        companies.add(Company.builder()
+                .id(1L)
+                .companyName("ABC 테크")
+                .companyAddress("서울시 강남구")
+                .latitude(new BigDecimal("37.5"))
+                .longitude(new BigDecimal("127.0"))
+                .establishmentDate(LocalDate.of(2010, 1, 1))
+                .companyImageUrl("company_image_1.jpg")
+                .companyDescription("ABC 테크는 혁신적인 기술 회사입니다.")
+                .build());
+
+        // 두 번째 회사
+        companies.add(Company.builder()
+                .id(2L)
+                .companyName("XYZ 테크놀로지")
+                .companyAddress("서울시 서초구")
+                .latitude(new BigDecimal("37.4"))
+                .longitude(new BigDecimal("127.1"))
+                .establishmentDate(LocalDate.of(2015, 5, 10))
+                .companyImageUrl("company_image_2.jpg")
+                .companyDescription("XYZ 테크놀로지는 최첨단 기술을 개발하는 회사입니다.")
+                .build());
+
+        return companies;
+    }
+}


### PR DESCRIPTION
# 🚀 What’s this PR about?

- 채용 공고 조회 시, 기업 명을 키워드로 검색하는 기능

# 🛠️ What’s been done?

- `CompanyService` 내에 `searchCompaniesByKeyword(String keyword)` 메서드 추가
- `keyword`가 null 또는 공백일 경우 전체 기업 조회, 아닐 경우 like 검색 처리
- `RecruitmentController`에 `/recruitments/companies` GET API 추가
- 응답 DTO로 `RecruitmentCompanySearchResponseDTO` 사용
- 빈 결과 시 `204 No Content`, keyword 누락 시 예외 처리 제거
- 테스트 코드 작성
- 
# 🧪 Testing Details

- `CompanyServiceTest`에서 유닛 테스트 추가
- 빈 키워드 → `findAll()` 호출 확인
- 유효한 키워드 → `findByCompanyNameContainingIgnoreCase()` 호출 확인
- 모든 API 테스트 정상 통과

# 👀 Checkpoints for Reviewers


# 📚 References & Resources


# 🎯 Related Issues
- close#36 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 회사명을 키워드로 검색할 수 있는 신규 엔드포인트가 추가되었습니다.
  * 검색 결과는 회사 ID와 회사명을 포함하여 반환됩니다.

* **문서화**
  * 채용 목록 조회 메서드에 대한 Javadoc 주석이 추가되었습니다.

* **테스트**
  * 회사명 검색 엔드포인트에 대한 HTTP 테스트 케이스가 추가되었습니다.
  * 회사명 검색 서비스의 동작을 검증하는 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->