### PR TITLE
홈 채용 공고 기능 조회

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/controller/RecruitmentController.java
@@ -61,4 +61,17 @@ public class RecruitmentController {
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
+
+    @Operation(summary = "최신 채용 공고 조회", description = "홈 화면에 보여질 최신 채용 공고 목록을 조회합니다 (최신 수정일 기준)")
+    @GetMapping("/home")
+    public ResponseEntity<Response<List<RecruitmentResponseDTO>>> findLatestRecruitments() {
+        List<RecruitmentResponseDTO> result = recruitmentService.findLatestRecruitments();
+
+        Response<List<RecruitmentResponseDTO>> response = Response.<List<RecruitmentResponseDTO>>builder()
+                .message("최신 채용 공고 조회 성공")
+                .data(result)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
 }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/controller/RecruitmentController.java
@@ -65,7 +65,8 @@ public class RecruitmentController {
     @Operation(summary = "최신 채용 공고 조회", description = "홈 화면에 보여질 최신 채용 공고 목록을 조회합니다 (최신 수정일 기준)")
     @GetMapping("/home")
     public ResponseEntity<Response<List<RecruitmentResponseDTO>>> findLatestRecruitments() {
-        List<RecruitmentResponseDTO> result = recruitmentService.findLatestRecruitments();
+        int limit = 5;
+        List<RecruitmentResponseDTO> result = recruitmentService.findLatestRecruitments(limit);
 
         Response<List<RecruitmentResponseDTO>> response = Response.<List<RecruitmentResponseDTO>>builder()
                 .message("최신 채용 공고 조회 성공")

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentResponseDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentResponseDTO.java
@@ -23,10 +23,12 @@ public class RecruitmentResponseDTO {
     private BigDecimal latitude; // 위도
     private BigDecimal longitude; // 경도
 
+    private LocalDateTime modifiedAt;
+
     // JPA 에서 사용되는 생성자
     public RecruitmentResponseDTO(Long id, String title, String companyName, String companyImageUrl,
                                   LocalDateTime dueDate, Integer experience, String workLocation,
-                                  BigDecimal latitude, BigDecimal longitude) {
+                                  BigDecimal latitude, BigDecimal longitude, LocalDateTime modifiedAt) {
         this.id = id;
         this.title = title;
         this.companyName = companyName;
@@ -36,6 +38,7 @@ public class RecruitmentResponseDTO {
         this.workLocation = workLocation;
         this.latitude = latitude;
         this.longitude = longitude;
+        this.modifiedAt = modifiedAt;
     }
 
     // 서비스 단에서 Recruitment 엔티티를 DTO로 변환하는 메서드
@@ -50,6 +53,7 @@ public class RecruitmentResponseDTO {
                 .workLocation(recruitment.getWorkLocation())
                 .latitude(recruitment.getCompany().getLatitude())
                 .longitude(recruitment.getCompany().getLongitude())
+                .modifiedAt(recruitment.getModifiedAt())
                 .build();
     }
 }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/entity/Recruitment.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/entity/Recruitment.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.hugmeexp.domain.recruitment.enums.SourceType;
+import org.example.hugmeexp.global.entity.BaseEntity;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -17,7 +18,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder(toBuilder = true)
 @Table(name = "recruitment")
-public class Recruitment {
+public class Recruitment extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
@@ -13,10 +13,17 @@ import java.util.List;
 @Repository
 public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> {
 
+    /**
+     * 검색 조건에 맞는 채용 공고 목록을 조회합니다.
+     * 조건에 따라 필터링된 결과를 반환합니다.
+     *
+     * @param cond 검색 조건 DTO
+     * @return 채용 공고 목록
+     */
     @Query("""
         SELECT new org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO(
             r.id, r.title, c.companyName, c.companyImageUrl, r.dueDate, r.experience,
-            r.workLocation, r.latitude, r.longitude
+            r.workLocation, r.latitude, r.longitude, r.modifiedAt
         )
         FROM Recruitment r
         JOIN r.company c
@@ -34,10 +41,27 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
               (:#{#cond.techStacks} IS NULL OR ts.id IN :#{#cond.techStacks}) AND
               (:#{#cond.tags} IS NULL OR t.id IN :#{#cond.tags})
         GROUP BY r.id, r.title, c.companyName, c.companyImageUrl, r.dueDate, r.experience,
-                 r.workLocation, r.latitude, r.longitude
+                 r.workLocation, r.latitude, r.longitude, r.modifiedAt
         HAVING (:#{#cond.techStacks} IS NULL OR COUNT(DISTINCT ts.id) = :#{#cond.techStackCount}) AND
                (:#{#cond.tags} IS NULL OR COUNT(DISTINCT t.id) = :#{#cond.tagCount})
     """)
     List<RecruitmentResponseDTO> findBySearchConditions(@Param("cond") RecruitmentSearchConditionDTO cond);
 
+
+    /**
+     * 최신 수정일 기준으로 정렬된 채용 공고 목록을 조회합니다.
+     * 별도의 검색 조건 없이, 최신 공고를 우선순위로 반환합니다.
+     *
+     * @return 최신 채용 공고 목록
+     */
+    @Query("""
+        SELECT new org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO(
+            r.id, r.title, c.companyName, c.companyImageUrl, r.dueDate, r.experience,
+            r.workLocation, r.latitude, r.longitude, r.modifiedAt
+        )
+        FROM Recruitment r
+        JOIN r.company c
+        ORDER BY r.modifiedAt DESC
+    """)
+    List<RecruitmentResponseDTO> findLatestRecruitments();
 }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
@@ -3,6 +3,7 @@ package org.example.hugmeexp.domain.recruitment.repository;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentSearchConditionDTO;
 import org.example.hugmeexp.domain.recruitment.entity.Recruitment;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -50,9 +51,10 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
 
     /**
      * 최신 수정일 기준으로 정렬된 채용 공고 목록을 조회합니다.
-     * 별도의 검색 조건 없이, 최신 공고를 우선순위로 반환합니다.
+     * Pageable을 사용하여 원하는 개수만큼 제한하여 가져옵니다.
      *
-     * @return 최신 채용 공고 목록
+     * @param pageable 페이징 및 정렬 정보를 담은 객체
+     * @return 최신 채용 공고 목록 (modifiedAt 기준 내림차순 정렬)
      */
     @Query("""
         SELECT new org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO(
@@ -63,5 +65,5 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
         JOIN r.company c
         ORDER BY r.modifiedAt DESC
     """)
-    List<RecruitmentResponseDTO> findLatestRecruitments();
+    List<RecruitmentResponseDTO> findLatestRecruitments(Pageable pageable);
 }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentSearchConditionDTO;
 import org.example.hugmeexp.domain.recruitment.repository.RecruitmentRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,7 +44,8 @@ public class RecruitmentService {
      *
      * @return 최신 채용 공고 목록
      */
-    public List<RecruitmentResponseDTO> findLatestRecruitments() {
-        return recruitmentRepository.findLatestRecruitments();
+    public List<RecruitmentResponseDTO> findLatestRecruitments(int limit) {
+        Pageable pageable = PageRequest.of(0, limit);
+        return recruitmentRepository.findLatestRecruitments(pageable);
     }
 }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
@@ -35,4 +35,14 @@ public class RecruitmentService {
 
         return recruitmentRepository.findBySearchConditions(enrichedCond);
     }
+
+    /**
+     * 최신 채용 공고 목록을 조회합니다.
+     * 수정일 기준으로 정렬된 최신 채용 공고를 반환합니다.
+     *
+     * @return 최신 채용 공고 목록
+     */
+    public List<RecruitmentResponseDTO> findLatestRecruitments() {
+        return recruitmentRepository.findLatestRecruitments();
+    }
 }

--- a/src/test/http/recruitment.http
+++ b/src/test/http/recruitment.http
@@ -49,3 +49,9 @@ Authorization: Bearer {{accessToken}}
 ### ❌ 채용 기업 키워드 누락 (예외 테스트)
 GET {{baseUrl}}/recruitments/companies
 Authorization: Bearer {{accessToken}}
+
+
+
+### 🏠 홈 화면 - 최신 채용 공고 조회
+GET {{baseUrl}}/recruitments/home
+Authorization: Bearer {{accessToken}}

--- a/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -188,18 +189,19 @@ public class RecruitmentServiceTest {
     }
 
     @Test
-    @DisplayName("최신 채용 공고 목록 조회 테스트")
-    void findLatestRecruitments_ShouldReturnSortedByModifiedAt() {
+    @DisplayName("최신 채용 공고 목록 조회 테스트 - 페이지네이션 적용")
+    void findLatestRecruitments_ShouldReturnSortedByModifiedAtWithPagination() {
         // Given
-        List<RecruitmentResponseDTO> expectedResult = createSortedByModifiedAtMockResponseList();
-        when(recruitmentRepository.findLatestRecruitments()).thenReturn(expectedResult);
+        int limit = 5; // 페이지 크기 제한
+        List<RecruitmentResponseDTO> mockResponseList = createSortedByModifiedAtMockResponseList();
+        when(recruitmentRepository.findLatestRecruitments(any(Pageable.class))).thenReturn(mockResponseList.subList(0, 5));
 
         // When
-        List<RecruitmentResponseDTO> result = recruitmentService.findLatestRecruitments();
+        List<RecruitmentResponseDTO> result = recruitmentService.findLatestRecruitments(limit);
 
         // Then
-        assertEquals(expectedResult, result);
-        verify(recruitmentRepository).findLatestRecruitments();
+        assertEquals(5, result.size()); // 결과가 5개만 반환되는지 확인
+        verify(recruitmentRepository).findLatestRecruitments(any(Pageable.class));
 
         // 결과가 수정일 기준 내림차순으로 정렬되어 있는지 확인
         for (int i = 0; i < result.size() - 1; i++) {
@@ -234,31 +236,72 @@ public class RecruitmentServiceTest {
     }
 
     // 수정일 기준 내림차순으로 정렬된 테스트용 응답 DTO 리스트 생성 헬퍼 메소드
+    // 페이지네이션 테스트를 위해 8개의 아이템을 생성 (5개만 반환되어야 함)
     private List<RecruitmentResponseDTO> createSortedByModifiedAtMockResponseList() {
         List<RecruitmentResponseDTO> responses = new ArrayList<>();
 
-        // 가장 최근에 수정된 공고 (3일 전)
+        // 1. 가장 최근에 수정된 공고 (1일 전)
         responses.add(new RecruitmentResponseDTO(
                 1L, "백엔드 개발자 모집", "ABC 회사", "company_image_url_1.jpg",
                 LocalDateTime.of(2023, 12, 31, 23, 59),
                 3, "서울시 강남구", new BigDecimal("37.5"), new BigDecimal("127.0"),
-                LocalDateTime.now().minusDays(3)
+                LocalDateTime.now().minusDays(1)
         ));
 
-        // 중간에 수정된 공고 (7일 전)
+        // 2. 두 번째로 최근에 수정된 공고 (3일 전)
         responses.add(new RecruitmentResponseDTO(
                 2L, "프론트엔드 개발자 모집", "XYZ 회사", "company_image_url_2.jpg",
                 LocalDateTime.of(2023, 11, 30, 23, 59),
                 2, "서울시 서초구", new BigDecimal("37.4"), new BigDecimal("127.1"),
-                LocalDateTime.now().minusDays(7)
+                LocalDateTime.now().minusDays(3)
         ));
 
-        // 가장 오래전에 수정된 공고 (14일 전)
+        // 3. 세 번째로 최근에 수정된 공고 (5일 전)
         responses.add(new RecruitmentResponseDTO(
                 3L, "데이터 엔지니어 모집", "DEF 회사", "company_image_url_3.jpg",
                 LocalDateTime.of(2023, 12, 15, 23, 59),
                 5, "서울시 송파구", new BigDecimal("37.6"), new BigDecimal("127.2"),
+                LocalDateTime.now().minusDays(5)
+        ));
+
+        // 4. 네 번째로 최근에 수정된 공고 (7일 전)
+        responses.add(new RecruitmentResponseDTO(
+                4L, "모바일 개발자 모집", "GHI 회사", "company_image_url_4.jpg",
+                LocalDateTime.of(2023, 12, 20, 23, 59),
+                4, "서울시 마포구", new BigDecimal("37.55"), new BigDecimal("126.9"),
+                LocalDateTime.now().minusDays(7)
+        ));
+
+        // 5. 다섯 번째로 최근에 수정된 공고 (10일 전)
+        responses.add(new RecruitmentResponseDTO(
+                5L, "DevOps 엔지니어 모집", "JKL 회사", "company_image_url_5.jpg",
+                LocalDateTime.of(2023, 12, 25, 23, 59),
+                2, "서울시 영등포구", new BigDecimal("37.52"), new BigDecimal("126.93"),
+                LocalDateTime.now().minusDays(10)
+        ));
+
+        // 6. 여섯 번째로 최근에 수정된 공고 (14일 전)
+        responses.add(new RecruitmentResponseDTO(
+                6L, "QA 엔지니어 모집", "MNO 회사", "company_image_url_6.jpg",
+                LocalDateTime.of(2023, 12, 10, 23, 59),
+                3, "서울시 강동구", new BigDecimal("37.53"), new BigDecimal("127.12"),
                 LocalDateTime.now().minusDays(14)
+        ));
+
+        // 7. 일곱 번째로 최근에 수정된 공고 (20일 전)
+        responses.add(new RecruitmentResponseDTO(
+                7L, "보안 엔지니어 모집", "PQR 회사", "company_image_url_7.jpg",
+                LocalDateTime.of(2023, 12, 5, 23, 59),
+                6, "서울시 성동구", new BigDecimal("37.54"), new BigDecimal("127.05"),
+                LocalDateTime.now().minusDays(20)
+        ));
+
+        // 8. 여덟 번째로 최근에 수정된 공고 (30일 전)
+        responses.add(new RecruitmentResponseDTO(
+                8L, "시스템 엔지니어 모집", "STU 회사", "company_image_url_8.jpg",
+                LocalDateTime.of(2023, 11, 15, 23, 59),
+                4, "서울시 중구", new BigDecimal("37.56"), new BigDecimal("126.98"),
+                LocalDateTime.now().minusDays(30)
         ));
 
         return responses;

--- a/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -186,6 +187,29 @@ public class RecruitmentServiceTest {
         verify(recruitmentRepository).findBySearchConditions(any(RecruitmentSearchConditionDTO.class));
     }
 
+    @Test
+    @DisplayName("최신 채용 공고 목록 조회 테스트")
+    void findLatestRecruitments_ShouldReturnSortedByModifiedAt() {
+        // Given
+        List<RecruitmentResponseDTO> expectedResult = createSortedByModifiedAtMockResponseList();
+        when(recruitmentRepository.findLatestRecruitments()).thenReturn(expectedResult);
+
+        // When
+        List<RecruitmentResponseDTO> result = recruitmentService.findLatestRecruitments();
+
+        // Then
+        assertEquals(expectedResult, result);
+        verify(recruitmentRepository).findLatestRecruitments();
+
+        // 결과가 수정일 기준 내림차순으로 정렬되어 있는지 확인
+        for (int i = 0; i < result.size() - 1; i++) {
+            LocalDateTime current = result.get(i).getModifiedAt();
+            LocalDateTime next = result.get(i + 1).getModifiedAt();
+            assertTrue(current.isAfter(next) || current.isEqual(next), 
+                    "Results should be sorted by modifiedAt in descending order");
+        }
+    }
+
     // 테스트용 응답 DTO 리스트 생성 헬퍼 메소드
     private List<RecruitmentResponseDTO> createMockResponseList() {
         List<RecruitmentResponseDTO> responses = new ArrayList<>();
@@ -194,14 +218,47 @@ public class RecruitmentServiceTest {
         responses.add(new RecruitmentResponseDTO(
                 1L, "백엔드 개발자 모집", "ABC 회사", "company_image_url_1.jpg",
                 LocalDateTime.of(2023, 12, 31, 23, 59),
-                3, "서울시 강남구", new BigDecimal("37.5"), new BigDecimal("127.0")
+                3, "서울시 강남구", new BigDecimal("37.5"), new BigDecimal("127.0"),
+                LocalDateTime.now()
         ));
 
         // 두 번째 응답 DTO
         responses.add(new RecruitmentResponseDTO(
                 2L, "프론트엔드 개발자 모집", "XYZ 회사", "company_image_url_2.jpg",
                 LocalDateTime.of(2023, 11, 30, 23, 59),
-                2, "서울시 서초구", new BigDecimal("37.4"), new BigDecimal("127.1")
+                2, "서울시 서초구", new BigDecimal("37.4"), new BigDecimal("127.1"),
+                LocalDateTime.now()
+        ));
+
+        return responses;
+    }
+
+    // 수정일 기준 내림차순으로 정렬된 테스트용 응답 DTO 리스트 생성 헬퍼 메소드
+    private List<RecruitmentResponseDTO> createSortedByModifiedAtMockResponseList() {
+        List<RecruitmentResponseDTO> responses = new ArrayList<>();
+
+        // 가장 최근에 수정된 공고 (3일 전)
+        responses.add(new RecruitmentResponseDTO(
+                1L, "백엔드 개발자 모집", "ABC 회사", "company_image_url_1.jpg",
+                LocalDateTime.of(2023, 12, 31, 23, 59),
+                3, "서울시 강남구", new BigDecimal("37.5"), new BigDecimal("127.0"),
+                LocalDateTime.now().minusDays(3)
+        ));
+
+        // 중간에 수정된 공고 (7일 전)
+        responses.add(new RecruitmentResponseDTO(
+                2L, "프론트엔드 개발자 모집", "XYZ 회사", "company_image_url_2.jpg",
+                LocalDateTime.of(2023, 11, 30, 23, 59),
+                2, "서울시 서초구", new BigDecimal("37.4"), new BigDecimal("127.1"),
+                LocalDateTime.now().minusDays(7)
+        ));
+
+        // 가장 오래전에 수정된 공고 (14일 전)
+        responses.add(new RecruitmentResponseDTO(
+                3L, "데이터 엔지니어 모집", "DEF 회사", "company_image_url_3.jpg",
+                LocalDateTime.of(2023, 12, 15, 23, 59),
+                5, "서울시 송파구", new BigDecimal("37.6"), new BigDecimal("127.2"),
+                LocalDateTime.now().minusDays(14)
         ));
 
         return responses;


### PR DESCRIPTION
# 🚀 What’s this PR about?

- 홈 화면에서 최신 채용 공고 목록을 조회하는 API를 추가했습니다.
- modifiedAt 기준으로 최신순 정렬된 공고 리스트를 제공합니다.

# 🛠️ What’s been done?
  
- RecruitmentResponseDTO에 modifiedAt 필드 추가
- RecruitmentRepository.findLatestRecruitments() JPQL 수정 (ORDER BY r.modifiedAt DESC)
- RecruitmentService.getLatestRecruitments() 추가
- RecruitmentController에 /recruitments/home GET 엔드포인트 추가

# 🧪 Testing Details

- 단위 테스트 작성: findLatestRecruitments_ShouldReturnSortedByModifiedAt
 → modifiedAt 기준으로 정렬되어 있는지 검증 (내림차순 순서 보장)
- 수정일이 3일 전 > 7일 전 > 14일 전 순으로 정확히 정렬되는지 테스트

# 👀 Checkpoints for Reviewers

# 📚 References & Resources


# 🎯 Related Issues
- close#39 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 홈 화면에서 최신 채용 공고를 확인할 수 있는 GET 엔드포인트가 추가되었습니다.
  * 채용 공고 응답에 마지막 수정일(`modifiedAt`) 정보가 포함됩니다.

* **버그 수정**
  * 없음

* **테스트**
  * 홈 화면 최신 채용 공고 API에 대한 HTTP 테스트 케이스가 추가되었습니다.
  * 채용 공고가 수정일 기준으로 올바르게 정렬되어 반환되는지 검증하는 단위 테스트가 추가되었습니다.

* **문서화**
  * 신규 엔드포인트 및 메서드에 대한 설명이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->