### PR TITLE
채용 공고 상세 조회 api 구현

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/controller/RecruitmentController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentCompanySearchResponseDTO;
+import org.example.hugmeexp.domain.recruitment.dto.RecruitmentDetailResponseDTO;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentSearchConditionDTO;
 import org.example.hugmeexp.domain.recruitment.service.CompanyService;
@@ -70,6 +71,20 @@ public class RecruitmentController {
 
         Response<List<RecruitmentResponseDTO>> response = Response.<List<RecruitmentResponseDTO>>builder()
                 .message("최신 채용 공고 조회 성공")
+                .data(result)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @Operation(summary = "채용 공고 상세 조회", description = "채용 공고의 상세 정보를 조회합니다")
+    @GetMapping("/{id}")
+    public ResponseEntity<Response<RecruitmentDetailResponseDTO>> findRecruitmentDetail(@PathVariable Long id) {
+
+        RecruitmentDetailResponseDTO result = recruitmentService.getRecruitmentDetail(id);
+
+        Response<RecruitmentDetailResponseDTO> response = Response.<RecruitmentDetailResponseDTO>builder()
+                .message("채용 공고 상세 조회 성공")
                 .data(result)
                 .build();
 

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/controller/RecruitmentController.java
@@ -1,14 +1,14 @@
 package org.example.hugmeexp.domain.recruitment.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.example.hugmeexp.domain.recruitment.dto.RecruitmentCompanySearchResponseDTO;
-import org.example.hugmeexp.domain.recruitment.dto.RecruitmentDetailResponseDTO;
-import org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO;
-import org.example.hugmeexp.domain.recruitment.dto.RecruitmentSearchConditionDTO;
+import org.example.hugmeexp.domain.recruitment.dto.*;
 import org.example.hugmeexp.domain.recruitment.service.CompanyService;
 import org.example.hugmeexp.domain.recruitment.service.RecruitmentService;
 import org.example.hugmeexp.global.common.response.Response;
@@ -28,7 +28,20 @@ public class RecruitmentController {
     private final RecruitmentService recruitmentService;
     private final CompanyService companyService;
 
-    @Operation(summary = "채용 공고 목록 조회", description = "채용 공고 목록을 조회합니다")
+    @Operation(
+        summary = "채용 공고 목록 조회",
+        description = "조건에 따라 채용 공고 목록을 조회합니다",
+        responses = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "채용 공고 목록 조회 성공",
+                content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = RecruitmentListResponse.class)
+                )
+            )
+        }
+    )
     @GetMapping
     public ResponseEntity<Response<List<RecruitmentResponseDTO>>> listRecruitments(
             @Valid @ModelAttribute RecruitmentSearchConditionDTO conditionDTO) {
@@ -43,7 +56,24 @@ public class RecruitmentController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @Operation(summary = "채용 기업 목록 조회", description = "채용 기업 목록을 조회합니다")
+    @Operation(
+        summary = "채용 기업 목록 조회",
+        description = "채용 기업 목록을 조회합니다",
+        responses = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "기업 목록 조회 성공",
+                content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = CompanyListResponse.class)
+                )
+            ),
+            @ApiResponse(
+                responseCode = "204",
+                description = "결과 없음 (No Content)"
+            )
+        }
+    )
     @GetMapping("/companies")
     public ResponseEntity<Response<List<RecruitmentCompanySearchResponseDTO>>> searchCompanies(
             @RequestParam(required = false) String keyword
@@ -63,7 +93,20 @@ public class RecruitmentController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @Operation(summary = "최신 채용 공고 조회", description = "홈 화면에 보여질 최신 채용 공고 목록을 조회합니다 (최신 수정일 기준)")
+    @Operation(
+            summary = "최신 채용 공고 조회",
+            description = "홈 화면에 보여질 최신 채용 공고 목록을 조회합니다 (최신 수정일 기준)",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "최신 채용 공고 조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = RecruitmentListResponse.class)
+                            )
+                    )
+            }
+    )
     @GetMapping("/home")
     public ResponseEntity<Response<List<RecruitmentResponseDTO>>> findLatestRecruitments() {
         int limit = 5;
@@ -77,7 +120,24 @@ public class RecruitmentController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @Operation(summary = "채용 공고 상세 조회", description = "채용 공고의 상세 정보를 조회합니다")
+    @Operation(
+        summary = "채용 공고 상세 조회",
+        description = "채용 공고의 ID를 기준으로 상세 정보를 조회합니다",
+        responses = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "채용 공고 상세 조회 성공",
+                content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = RecruitmentDetailResponseDTO.class)
+                )
+            ),
+            @ApiResponse(
+                responseCode = "404",
+                description = "해당 ID의 채용 공고가 존재하지 않음"
+            )
+        }
+    )
     @GetMapping("/{id}")
     public ResponseEntity<Response<RecruitmentDetailResponseDTO>> findRecruitmentDetail(@PathVariable Long id) {
 

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/CompanyListResponse.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/CompanyListResponse.java
@@ -1,6 +1,8 @@
 package org.example.hugmeexp.domain.recruitment.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +11,8 @@ import java.util.List;
 @Schema(description = "채용 기업 목록 응답")
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
 public class CompanyListResponse {
 
     @Schema(description = "응답 메시지", example = "채용 기업 목록 조회 성공")

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/CompanyListResponse.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/CompanyListResponse.java
@@ -1,0 +1,20 @@
+package org.example.hugmeexp.domain.recruitment.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Schema(description = "채용 기업 목록 응답")
+@Getter
+@NoArgsConstructor
+public class CompanyListResponse {
+
+    @Schema(description = "응답 메시지", example = "채용 기업 목록 조회 성공")
+    private String message;
+
+    @Schema(description = "채용 기업 목록 데이터")
+    private List<RecruitmentCompanySearchResponseDTO> data;
+
+}

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentDetailResponseDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentDetailResponseDTO.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.hugmeexp.domain.recruitment.entity.Recruitment;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -32,4 +33,38 @@ public class RecruitmentDetailResponseDTO {
     private String qualifications;
     private String welfare;
     private String link;
+    private List<TagDTO> tags;
+
+    public static RecruitmentDetailResponseDTO from(Recruitment recruitment) {
+        return RecruitmentDetailResponseDTO.builder()
+                .id(recruitment.getId())
+                .title(recruitment.getTitle())
+                .companyName(recruitment.getCompany().getCompanyName())
+                .companyImageUrl(recruitment.getCompany().getCompanyImageUrl())
+                .companyAddress(recruitment.getCompany().getCompanyAddress())
+                .establishmentDate(recruitment.getCompany().getEstablishmentDate())
+                .companyDescription(recruitment.getCompany().getCompanyDescription())
+                .dueDate(recruitment.getDueDate())
+                .experience(recruitment.getExperience())
+                .education(recruitment.getEducation())
+                .salaryMin(recruitment.getSalaryMin())
+                .salaryMax(recruitment.getSalaryMax())
+                .techStacks(recruitment.getTechStacks().stream()
+                        .map(ts -> TechStackDTO.builder()
+                                .labelKo(ts.getTechItem().getKoreanName())
+                                .labelEn(ts.getTechItem().getEnglishName())
+                                .iconUrl(ts.getTechItem().getIconUrl())
+                                .build())
+                        .toList())
+                .advantage(recruitment.getAdvantage())
+                .qualifications(recruitment.getQualification())
+                .welfare(recruitment.getWelfare())
+                .link(recruitment.getLink())
+                .tags(recruitment.getTags().stream()
+                    .map(tag -> TagDTO.builder()
+                                    .tagName(tag.getTagItem().getTagName())
+                                    .build())
+                            .toList())
+                .build();
+    }
 }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentDetailResponseDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentDetailResponseDTO.java
@@ -1,0 +1,35 @@
+package org.example.hugmeexp.domain.recruitment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+public class RecruitmentDetailResponseDTO {
+
+    private Long id;
+    private String title;
+    private String companyName;
+    private String companyImageUrl;
+    private String companyAddress;
+    private LocalDate establishmentDate;
+    private String companyDescription;
+    private LocalDateTime dueDate;
+    private Integer experience;
+    private Integer education;
+    private Integer salaryMin;
+    private Integer salaryMax;
+    private List<TechStackDTO> techStacks;
+    private String advantage;
+    private String qualifications;
+    private String welfare;
+    private String link;
+}

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentListResponse.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentListResponse.java
@@ -1,10 +1,8 @@
 package org.example.hugmeexp.domain.recruitment.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.example.hugmeexp.global.common.response.Response;
 
 import java.util.List;
 

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentListResponse.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentListResponse.java
@@ -1,6 +1,8 @@
 package org.example.hugmeexp.domain.recruitment.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +11,8 @@ import java.util.List;
 @Schema(description = "채용 공고 목록 응답")
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
 public class RecruitmentListResponse {
 
     @Schema(description = "응답 메시지", example = "채용 공고 목록 조회 성공")

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentListResponse.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentListResponse.java
@@ -1,0 +1,21 @@
+package org.example.hugmeexp.domain.recruitment.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.hugmeexp.global.common.response.Response;
+
+import java.util.List;
+
+@Schema(description = "채용 공고 목록 응답")
+@Getter
+@NoArgsConstructor
+public class RecruitmentListResponse {
+
+    @Schema(description = "응답 메시지", example = "채용 공고 목록 조회 성공")
+    private String message;
+
+    @Schema(description = "채용 공고 목록 데이터")
+    private List<RecruitmentResponseDTO> data;
+}

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/TagDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/TagDTO.java
@@ -1,0 +1,15 @@
+package org.example.hugmeexp.domain.recruitment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+public class TagDTO {
+
+    private String tagName;
+}

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/TechStackDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/TechStackDTO.java
@@ -1,0 +1,17 @@
+package org.example.hugmeexp.domain.recruitment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+public class TechStackDTO {
+
+    private String labelKo;
+    private String labelEn;
+    private String iconUrl;
+}

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/exception/RecruitmentNotFoundException.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/exception/RecruitmentNotFoundException.java
@@ -1,0 +1,13 @@
+package org.example.hugmeexp.domain.recruitment.exception;
+
+import org.example.hugmeexp.global.common.exception.BaseCustomException;
+import org.example.hugmeexp.global.common.exception.code.ErrorStatus;
+
+public class RecruitmentNotFoundException extends BaseCustomException {
+
+    public RecruitmentNotFoundException(){
+        super(ErrorStatus.RECRUITMENT_NOT_FOUND.getHttpStatus(),
+              ErrorStatus.RECRUITMENT_NOT_FOUND.getMessage(),
+              ErrorStatus.RECRUITMENT_NOT_FOUND.getHttpStatus().value());
+    }
+}

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
@@ -76,9 +76,12 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
      * @return 채용 공고의 상세 정보 (존재하지 않을 경우 Optional.empty())
      */
     @Query("""
-        SELECT r FROM Recruitment r
+        SELECT DISTINCT r FROM Recruitment r
         JOIN FETCH r.company
         LEFT JOIN FETCH r.techStacks ts
+        LEFT JOIN FETCH ts.techItem
+        LEFT JOIN FETCH r.tags t
+        LEFT JOIN FETCH t.tagItem
         WHERE r.id = :id
     """)
     Optional<Recruitment> findDetailById(@Param("id") Long id);

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> {
@@ -66,4 +67,20 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
         ORDER BY r.modifiedAt DESC
     """)
     List<RecruitmentResponseDTO> findLatestRecruitments(Pageable pageable);
+
+    /**
+     * 채용 공고의 상세 정보를 ID로 조회합니다.
+     * 회사 정보, 기술 스택, 태그 등을 포함하여 상세 정보를 반환합니다.
+     *
+     * @param id 채용 공고 ID
+     * @return 채용 공고의 상세 정보 (존재하지 않을 경우 Optional.empty())
+     */
+    @Query("""
+        SELECT r FROM Recruitment r
+        JOIN FETCH r.company
+        LEFT JOIN FETCH r.techStacks ts
+        WHERE r.id = :id
+    """)
+    Optional<Recruitment> findDetailById(@Param("id") Long id);
+
 }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
@@ -2,8 +2,12 @@ package org.example.hugmeexp.domain.recruitment.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.hugmeexp.domain.recruitment.dto.RecruitmentDetailResponseDTO;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentSearchConditionDTO;
+import org.example.hugmeexp.domain.recruitment.dto.TechStackDTO;
+import org.example.hugmeexp.domain.recruitment.entity.Recruitment;
+import org.example.hugmeexp.domain.recruitment.exception.RecruitmentNotFoundException;
 import org.example.hugmeexp.domain.recruitment.repository.RecruitmentRepository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -47,5 +51,36 @@ public class RecruitmentService {
     public List<RecruitmentResponseDTO> findLatestRecruitments(int limit) {
         Pageable pageable = PageRequest.of(0, limit);
         return recruitmentRepository.findLatestRecruitments(pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public RecruitmentDetailResponseDTO getRecruitmentDetail(Long id){
+        Recruitment recruitment = recruitmentRepository.findDetailById(id).orElseThrow(() -> new RecruitmentNotFoundException());
+
+        return RecruitmentDetailResponseDTO.builder()
+                .id(recruitment.getId())
+                .title(recruitment.getTitle())
+                .companyName(recruitment.getCompany().getCompanyName())
+                .companyImageUrl(recruitment.getCompany().getCompanyImageUrl())
+                .companyAddress(recruitment.getCompany().getCompanyAddress())
+                .establishmentDate(recruitment.getCompany().getEstablishmentDate())
+                .companyDescription(recruitment.getCompany().getCompanyDescription())
+                .dueDate(recruitment.getDueDate())
+                .experience(recruitment.getExperience())
+                .education(recruitment.getEducation())
+                .salaryMin(recruitment.getSalaryMin())
+                .salaryMax(recruitment.getSalaryMax())
+                .techStacks(recruitment.getTechStacks().stream()
+                        .map(ts -> TechStackDTO.builder()
+                            .labelKo(ts.getTechItem().getKoreanName())
+                            .labelEn(ts.getTechItem().getEnglishName())
+                            .iconUrl(ts.getTechItem().getIconUrl())
+                            .build())
+                        .toList())
+                .advantage(recruitment.getAdvantage())
+                .qualifications(recruitment.getQualification())
+                .welfare(recruitment.getWelfare())
+                .link(recruitment.getLink())
+                .build();
     }
 }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentDetailResponseDTO;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentSearchConditionDTO;
-import org.example.hugmeexp.domain.recruitment.dto.TechStackDTO;
 import org.example.hugmeexp.domain.recruitment.entity.Recruitment;
 import org.example.hugmeexp.domain.recruitment.exception.RecruitmentNotFoundException;
 import org.example.hugmeexp.domain.recruitment.repository.RecruitmentRepository;

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
@@ -57,30 +57,6 @@ public class RecruitmentService {
     public RecruitmentDetailResponseDTO getRecruitmentDetail(Long id){
         Recruitment recruitment = recruitmentRepository.findDetailById(id).orElseThrow(() -> new RecruitmentNotFoundException());
 
-        return RecruitmentDetailResponseDTO.builder()
-                .id(recruitment.getId())
-                .title(recruitment.getTitle())
-                .companyName(recruitment.getCompany().getCompanyName())
-                .companyImageUrl(recruitment.getCompany().getCompanyImageUrl())
-                .companyAddress(recruitment.getCompany().getCompanyAddress())
-                .establishmentDate(recruitment.getCompany().getEstablishmentDate())
-                .companyDescription(recruitment.getCompany().getCompanyDescription())
-                .dueDate(recruitment.getDueDate())
-                .experience(recruitment.getExperience())
-                .education(recruitment.getEducation())
-                .salaryMin(recruitment.getSalaryMin())
-                .salaryMax(recruitment.getSalaryMax())
-                .techStacks(recruitment.getTechStacks().stream()
-                        .map(ts -> TechStackDTO.builder()
-                            .labelKo(ts.getTechItem().getKoreanName())
-                            .labelEn(ts.getTechItem().getEnglishName())
-                            .iconUrl(ts.getTechItem().getIconUrl())
-                            .build())
-                        .toList())
-                .advantage(recruitment.getAdvantage())
-                .qualifications(recruitment.getQualification())
-                .welfare(recruitment.getWelfare())
-                .link(recruitment.getLink())
-                .build();
+        return RecruitmentDetailResponseDTO.from(recruitment);
     }
 }

--- a/src/main/java/org/example/hugmeexp/global/common/exception/code/ErrorStatus.java
+++ b/src/main/java/org/example/hugmeexp/global/common/exception/code/ErrorStatus.java
@@ -1,6 +1,7 @@
 package org.example.hugmeexp.global.common.exception.code;
 
 import lombok.RequiredArgsConstructor;
+import org.example.hugmeexp.domain.recruitment.entity.Recruitment;
 import org.springframework.http.HttpStatus;
 
 /**
@@ -17,8 +18,9 @@ public enum ErrorStatus implements BaseCode {
     FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
 
     // Domain Specific
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다.");
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
     // TODO: 필요한 도메인별 에러 코드를 여기에 추가
+    RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 모집 공고를 찾을 수 없습니다.");
 
     public static final String PREFIX = "[ERROR]";
 

--- a/src/main/java/org/example/hugmeexp/global/common/exception/code/ErrorStatus.java
+++ b/src/main/java/org/example/hugmeexp/global/common/exception/code/ErrorStatus.java
@@ -1,7 +1,6 @@
 package org.example.hugmeexp.global.common.exception.code;
 
 import lombok.RequiredArgsConstructor;
-import org.example.hugmeexp.domain.recruitment.entity.Recruitment;
 import org.springframework.http.HttpStatus;
 
 /**

--- a/src/test/http/recruitment.http
+++ b/src/test/http/recruitment.http
@@ -55,3 +55,13 @@ Authorization: Bearer {{accessToken}}
 ### 🏠 홈 화면 - 최신 채용 공고 조회
 GET {{baseUrl}}/recruitments/home
 Authorization: Bearer {{accessToken}}
+
+
+
+### 📝 채용 공고 상세 조회 (예: id = 1)
+GET {{baseUrl}}/recruitments/1
+Authorization: Bearer {{accessToken}}
+
+### ❌ 채용 공고 상세 조회 - 존재하지 않는 ID
+GET {{baseUrl}}/recruitments/99999
+Authorization: Bearer {{accessToken}}

--- a/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
@@ -1,7 +1,14 @@
 package org.example.hugmeexp.domain.recruitment.service;
 
+import org.example.hugmeexp.domain.recruitment.dto.RecruitmentDetailResponseDTO;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentSearchConditionDTO;
+import org.example.hugmeexp.domain.recruitment.dto.TechStackDTO;
+import org.example.hugmeexp.domain.recruitment.entity.Company;
+import org.example.hugmeexp.domain.recruitment.entity.Recruitment;
+import org.example.hugmeexp.domain.recruitment.entity.TechItem;
+import org.example.hugmeexp.domain.recruitment.entity.TechStack;
+import org.example.hugmeexp.domain.recruitment.exception.RecruitmentNotFoundException;
 import org.example.hugmeexp.domain.recruitment.repository.RecruitmentRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,12 +19,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Pageable;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -305,5 +313,127 @@ public class RecruitmentServiceTest {
         ));
 
         return responses;
+    }
+
+    @Test
+    @DisplayName("채용 공고 상세 조회 성공 테스트")
+    void getRecruitmentDetail_Success() {
+        // Given
+        Long recruitmentId = 1L;
+
+        // 회사 정보 생성
+        Company company = Company.builder()
+                .id(1L)
+                .companyName("ABC 회사")
+                .companyAddress("서울시 강남구 테헤란로 123")
+                .latitude(new BigDecimal("37.5"))
+                .longitude(new BigDecimal("127.0"))
+                .establishmentDate(LocalDate.of(2010, 1, 1))
+                .companyImageUrl("company_image_url_1.jpg")
+                .companyDescription("좋은 회사입니다.")
+                .build();
+
+        // 기술 스택 아이템 생성 (생성자 사용)
+        TechItem techItem1 = new TechItem(1L, "Java", "자바", "java_icon.png");
+
+        TechItem techItem2 = new TechItem(2L, "Spring", "스프링", "spring_icon.png");
+
+        // 채용 공고 생성
+        Recruitment recruitment = Recruitment.builder()
+                .id(recruitmentId)
+                .title("백엔드 개발자 모집")
+                .education(4)
+                .experience(3)
+                .qualification("Java, Spring 경험자")
+                .advantage("MSA 경험자 우대")
+                .welfare("점심 제공, 4대 보험")
+                .workLocation("서울시 강남구")
+                .latitude(new BigDecimal("37.5"))
+                .longitude(new BigDecimal("127.0"))
+                .salaryMin(3000)
+                .salaryMax(5000)
+                .link("https://example.com/job/1")
+                .dueDate(LocalDateTime.of(2023, 12, 31, 23, 59))
+                .company(company)
+                .build();
+
+        // 기술 스택 생성 및 연결
+        List<TechStack> techStacks = new ArrayList<>();
+        TechStack techStack1 = TechStack.builder()
+                .id(1L)
+                .recruitment(recruitment)
+                .techItem(techItem1)
+                .build();
+
+        TechStack techStack2 = TechStack.builder()
+                .id(2L)
+                .recruitment(recruitment)
+                .techItem(techItem2)
+                .build();
+
+        techStacks.add(techStack1);
+        techStacks.add(techStack2);
+
+        // 채용 공고에 기술 스택 설정
+        recruitment = recruitment.toBuilder()
+                .techStacks(techStacks)
+                .build();
+
+        // Repository mock 설정
+        when(recruitmentRepository.findDetailById(recruitmentId)).thenReturn(Optional.of(recruitment));
+
+        // When
+        RecruitmentDetailResponseDTO result = recruitmentService.getRecruitmentDetail(recruitmentId);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(recruitmentId, result.getId());
+        assertEquals("백엔드 개발자 모집", result.getTitle());
+        assertEquals("ABC 회사", result.getCompanyName());
+        assertEquals("company_image_url_1.jpg", result.getCompanyImageUrl());
+        assertEquals("서울시 강남구 테헤란로 123", result.getCompanyAddress());
+        assertEquals(LocalDate.of(2010, 1, 1), result.getEstablishmentDate());
+        assertEquals("좋은 회사입니다.", result.getCompanyDescription());
+        assertEquals(LocalDateTime.of(2023, 12, 31, 23, 59), result.getDueDate());
+        assertEquals(3, result.getExperience());
+        assertEquals(4, result.getEducation());
+        assertEquals(3000, result.getSalaryMin());
+        assertEquals(5000, result.getSalaryMax());
+        assertEquals("Java, Spring 경험자", result.getQualifications());
+        assertEquals("MSA 경험자 우대", result.getAdvantage());
+        assertEquals("점심 제공, 4대 보험", result.getWelfare());
+        assertEquals("https://example.com/job/1", result.getLink());
+
+        // 기술 스택 검증
+        assertEquals(2, result.getTechStacks().size());
+
+        TechStackDTO techStackDTO1 = result.getTechStacks().get(0);
+        assertEquals("자바", techStackDTO1.getLabelKo());
+        assertEquals("Java", techStackDTO1.getLabelEn());
+        assertEquals("java_icon.png", techStackDTO1.getIconUrl());
+
+        TechStackDTO techStackDTO2 = result.getTechStacks().get(1);
+        assertEquals("스프링", techStackDTO2.getLabelKo());
+        assertEquals("Spring", techStackDTO2.getLabelEn());
+        assertEquals("spring_icon.png", techStackDTO2.getIconUrl());
+
+        // Repository 호출 검증
+        verify(recruitmentRepository).findDetailById(recruitmentId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 채용 공고 상세 조회 테스트")
+    void getRecruitmentDetail_NotFound() {
+        // Given
+        Long nonExistentId = 999L;
+        when(recruitmentRepository.findDetailById(nonExistentId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(RecruitmentNotFoundException.class, () -> {
+            recruitmentService.getRecruitmentDetail(nonExistentId);
+        });
+
+        // Repository 호출 검증
+        verify(recruitmentRepository).findDetailById(nonExistentId);
     }
 }

--- a/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
@@ -6,6 +6,8 @@ import org.example.hugmeexp.domain.recruitment.dto.RecruitmentSearchConditionDTO
 import org.example.hugmeexp.domain.recruitment.dto.TechStackDTO;
 import org.example.hugmeexp.domain.recruitment.entity.Company;
 import org.example.hugmeexp.domain.recruitment.entity.Recruitment;
+import org.example.hugmeexp.domain.recruitment.entity.Tag;
+import org.example.hugmeexp.domain.recruitment.entity.TagItem;
 import org.example.hugmeexp.domain.recruitment.entity.TechItem;
 import org.example.hugmeexp.domain.recruitment.entity.TechStack;
 import org.example.hugmeexp.domain.recruitment.exception.RecruitmentNotFoundException;
@@ -374,9 +376,31 @@ public class RecruitmentServiceTest {
         techStacks.add(techStack1);
         techStacks.add(techStack2);
 
-        // 채용 공고에 기술 스택 설정
+        // 태그 아이템 생성
+        TagItem tagItem1 = new TagItem(1L, "신입");
+        TagItem tagItem2 = new TagItem(2L, "경력");
+
+        // 태그 생성 및 연결
+        List<Tag> tags = new ArrayList<>();
+        Tag tag1 = Tag.builder()
+                .id(1L)
+                .recruitment(recruitment)
+                .tagItem(tagItem1)
+                .build();
+
+        Tag tag2 = Tag.builder()
+                .id(2L)
+                .recruitment(recruitment)
+                .tagItem(tagItem2)
+                .build();
+
+        tags.add(tag1);
+        tags.add(tag2);
+
+        // 채용 공고에 기술 스택과 태그 설정
         recruitment = recruitment.toBuilder()
                 .techStacks(techStacks)
+                .tags(tags)
                 .build();
 
         // Repository mock 설정


### PR DESCRIPTION
# 🚀 What’s this PR about?

- 사용자가 채용 공고를 클릭했을 때 상세 정보를 확인할 수 있도록 하는 API를 추가했습니다.

# 🛠️ What’s been done?

- RecruitmentDetailResponseDTO 생성 및 응답 필드 구성
- RecruitmentRepository.findDetailById() 쿼리 작성
- RecruitmentService.getRecruitmentDetail() 서비스 메서드 구현
- /api/recruitments/{id} 컨트롤러 추가
- RecruitmentNotFoundException 정의 

# 🧪 Testing Details

- RecruitmentServiceTest.getRecruitmentDetail_Success
→ 존재하는 ID로 채용 공고 상세 조회 성공
→ 회사 정보, 기술 스택 포함 전체 필드 정확하게 매핑 확인
- RecruitmentServiceTest.getRecruitmentDetail_NotFound
→ 존재하지 않는 ID 요청 시 RecruitmentNotFoundException 발생 확인

# 👀 Checkpoints for Reviewers


# 📚 References & Resources


# 🎯 Related Issues
- close#42 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 채용 공고 상세 조회 API 엔드포인트가 추가되어, 채용 공고의 상세 정보를 ID로 조회할 수 있습니다.
  * 채용 공고 상세 정보에 회사 정보, 기술 스택, 태그 등이 포함되어 더욱 풍부한 정보를 제공합니다.

* **버그 수정**
  * 채용 공고를 찾을 수 없는 경우에 대한 명확한 에러 메시지가 추가되었습니다.

* **테스트**
  * 채용 공고 상세 조회 성공 및 실패(존재하지 않는 ID) 시나리오에 대한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->