### PR TITLE
[BugFix] 중복 태그 및 기술 스택 처리 로직 추가

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/CompanyRequestDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/CompanyRequestDTO.java
@@ -26,7 +26,7 @@ public class CompanyRequestDTO {
 
     private BigDecimal longitude;
 
-    @PastOrPresent(message = "설립일은 현재 날짜 이전이어야 합니다")
+    //@PastOrPresent(message = "설립일은 현재 날짜 이전이어야 합니다")
     private LocalDate establishmentDate;
 
     @Size(max = 1000, message = "회사 이미지 URL은 1000자를 초과할 수 없습니다")

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/CompanyRequestDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/CompanyRequestDTO.java
@@ -25,8 +25,7 @@ public class CompanyRequestDTO {
     private BigDecimal latitude;
 
     private BigDecimal longitude;
-
-    //@PastOrPresent(message = "설립일은 현재 날짜 이전이어야 합니다")
+    
     private LocalDate establishmentDate;
 
     @Size(max = 1000, message = "회사 이미지 URL은 1000자를 초과할 수 없습니다")

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentDetailResponseDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentDetailResponseDTO.java
@@ -9,6 +9,7 @@ import org.example.hugmeexp.domain.recruitment.entity.Recruitment;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @AllArgsConstructor
@@ -59,7 +60,7 @@ public class RecruitmentDetailResponseDTO {
                                 .labelEn(ts.getTechItem().getEnglishName())
                                 .iconUrl(ts.getTechItem().getIconUrl())
                                 .build())
-                        .toList())
+                        .collect(Collectors.toSet()).stream().toList())
                 .advantage(recruitment.getAdvantage())
                 .qualifications(recruitment.getQualification())
                 .welfare(recruitment.getWelfare())
@@ -69,7 +70,7 @@ public class RecruitmentDetailResponseDTO {
                                     .id(tag.getTagItem().getId())
                                     .tagName(tag.getTagItem().getTagName())
                                     .build())
-                            .toList())
+                        .collect(Collectors.toSet()).stream().toList())
                 .recruitmentSourceId(recruitment.getRecruitmentSourceId())
                 .build();
     }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentDetailResponseDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentDetailResponseDTO.java
@@ -9,7 +9,6 @@ import org.example.hugmeexp.domain.recruitment.entity.Recruitment;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @AllArgsConstructor
@@ -60,7 +59,7 @@ public class RecruitmentDetailResponseDTO {
                                 .labelEn(ts.getTechItem().getEnglishName())
                                 .iconUrl(ts.getTechItem().getIconUrl())
                                 .build())
-                        .collect(Collectors.toSet()).stream().toList())
+                        .distinct().toList())
                 .advantage(recruitment.getAdvantage())
                 .qualifications(recruitment.getQualification())
                 .welfare(recruitment.getWelfare())
@@ -70,7 +69,7 @@ public class RecruitmentDetailResponseDTO {
                                     .id(tag.getTagItem().getId())
                                     .tagName(tag.getTagItem().getTagName())
                                     .build())
-                        .collect(Collectors.toSet()).stream().toList())
+                        .distinct().toList())
                 .recruitmentSourceId(recruitment.getRecruitmentSourceId())
                 .build();
     }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/TagDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/TagDTO.java
@@ -6,11 +6,24 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.hugmeexp.domain.recruitment.entity.TagItem;
 
+import java.util.Objects;
+
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder(toBuilder = true)
 public class TagDTO {
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        TagDTO tagDTO = (TagDTO) o;
+        return Objects.equals(tagName, tagDTO.tagName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(tagName);
+    }
 
     private Long id;
     private String tagName;

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/TagRequestDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/TagRequestDTO.java
@@ -1,16 +1,19 @@
 package org.example.hugmeexp.domain.recruitment.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import org.example.hugmeexp.domain.recruitment.entity.TagItem;
 import org.hibernate.validator.constraints.Length;
 
+import java.util.Objects;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class TagRequestDTO {
+public class TagRequestDTO implements Comparable<TagRequestDTO> {
     @NotBlank
     @Length(max = 100, message = "태그 이름은 100자를 초과할 수 없습니다")
     private String tagName;
@@ -19,5 +22,26 @@ public class TagRequestDTO {
         return TagItem.builder()
                 .tagName(tagName)
                 .build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        TagRequestDTO that = (TagRequestDTO) o;
+        return Objects.equals(tagName, that.tagName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(tagName);
+    }
+
+    @Override
+    public int compareTo(TagRequestDTO o) {
+        if (o == null) return 1; // null is considered greater
+        if (this.tagName == null && o.tagName == null) return 0; // both are null
+        if (this.tagName == null) return -1; // this is less than o
+        if (o.tagName == null) return 1; // this is greater than o
+        return this.tagName.compareTo(o.tagName); // compare tag names
     }
 }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/TagRequestDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/TagRequestDTO.java
@@ -1,7 +1,6 @@
 package org.example.hugmeexp.domain.recruitment.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/TechItemRequestDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/TechItemRequestDTO.java
@@ -6,10 +6,12 @@ import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import org.example.hugmeexp.domain.recruitment.entity.TechItem;
 
+import java.util.Objects;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class TechItemRequestDTO {
+public class TechItemRequestDTO implements Comparable<TechItemRequestDTO> {
     @NotBlank(message = "한글명은 필수입니다")
     @Size(max = 100, message = "영문명은 100자를 초과할 수 없습니다")
     private String englishName;
@@ -26,5 +28,31 @@ public class TechItemRequestDTO {
                 .koreanName(koreanName)
                 .iconUrl(iconUrl)
                 .build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        TechItemRequestDTO that = (TechItemRequestDTO) o;
+        return Objects.equals(englishName, that.englishName) && Objects.equals(koreanName, that.koreanName) && Objects.equals(iconUrl, that.iconUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(englishName, koreanName, iconUrl);
+    }
+
+    @Override
+    public int compareTo(TechItemRequestDTO o) {
+        if (o == null) return 1; // null is considered greater
+        int englishComparison = this.englishName.compareTo(o.englishName);
+        if (englishComparison != 0) {
+            return englishComparison;
+        }
+        int koreanComparison = this.koreanName.compareTo(o.koreanName);
+        if (koreanComparison != 0) {
+            return koreanComparison;
+        }
+        return this.iconUrl.compareTo(o.iconUrl);
     }
 }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/TechItemRequestDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/TechItemRequestDTO.java
@@ -45,14 +45,6 @@ public class TechItemRequestDTO implements Comparable<TechItemRequestDTO> {
     @Override
     public int compareTo(TechItemRequestDTO o) {
         if (o == null) return 1; // null is considered greater
-        int englishComparison = this.englishName.compareTo(o.englishName);
-        if (englishComparison != 0) {
-            return englishComparison;
-        }
-        int koreanComparison = this.koreanName.compareTo(o.koreanName);
-        if (koreanComparison != 0) {
-            return koreanComparison;
-        }
-        return this.iconUrl.compareTo(o.iconUrl);
+        return this.englishName.compareTo(o.englishName);
     }
 }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/TechStackDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/TechStackDTO.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.hugmeexp.domain.recruitment.entity.TechItem;
 
+import java.util.Objects;
+
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
@@ -24,5 +26,17 @@ public class TechStackDTO {
                 .labelEn(techItem.getEnglishName())
                 .iconUrl(techItem.getIconUrl())
                 .build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        TechStackDTO that = (TechStackDTO) o;
+        return Objects.equals(labelKo, that.labelKo) && Objects.equals(labelEn, that.labelEn) && Objects.equals(iconUrl, that.iconUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(labelKo, labelEn, iconUrl);
     }
 }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/entity/Tag.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/entity/Tag.java
@@ -11,7 +11,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(toBuilder = true)
-@Table(name = "tag")
+@Table(name = "tag", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"recruitment_id", "tag_item_id"})
+})
 public class Tag {
 
     @Id

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/entity/TechStack.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/entity/TechStack.java
@@ -11,7 +11,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(toBuilder = true)
-@Table(name = "tech_stack")
+@Table(name = "tech_stack", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"recruitment_id", "tech_item_id"})
+})
 public class TechStack {
 
     @Id

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/repository/TagRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/repository/TagRepository.java
@@ -2,7 +2,9 @@ package org.example.hugmeexp.domain.recruitment.repository;
 
 import org.example.hugmeexp.domain.recruitment.entity.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface TagRepository extends JpaRepository<Tag, Long> {
 
 }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/repository/TechStackRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/repository/TechStackRepository.java
@@ -2,6 +2,8 @@ package org.example.hugmeexp.domain.recruitment.repository;
 
 import org.example.hugmeexp.domain.recruitment.entity.TechStack;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface TechStackRepository extends JpaRepository<TechStack, Long> {
 }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
@@ -18,16 +18,12 @@ import org.example.hugmeexp.domain.recruitment.repository.TechItemRepository;
 import org.example.hugmeexp.domain.recruitment.repository.TechStackRepository;
 import org.example.hugmeexp.domain.recruitment.repository.TagRepository;
 import org.example.hugmeexp.domain.recruitment.repository.CompanyRepository;
-import org.example.hugmeexp.global.common.exception.BaseCustomException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -161,6 +157,18 @@ public class RecruitmentService {
 
     @Transactional
     public RecruitmentResponseDTO createOrUpdateRecruitment(RecruitmentRequestDTO requestDTO) {
+        // 태그 및 기술 스택의 중복 제거 및 정렬
+        Set<TagRequestDTO> uniqueTags = new TreeSet<>(Comparator.comparing(TagRequestDTO::getTagName));
+        if (requestDTO.getTags() != null) {
+            uniqueTags.addAll(requestDTO.getTags());
+        }
+        requestDTO.setTags(new ArrayList<>(uniqueTags));
+        Set<TechItemRequestDTO> uniqueTechItems = new TreeSet<>(Comparator.comparing(TechItemRequestDTO::getEnglishName));
+        if (requestDTO.getRequiredSkills() != null) {
+            uniqueTechItems.addAll(requestDTO.getRequiredSkills());
+        }
+        requestDTO.setRequiredSkills(new ArrayList<>(uniqueTechItems));
+        
         Optional<Recruitment> existingRecruitment = recruitmentRepository.findByRecruitmentSourceId(requestDTO.getRecruitmentSourceId());
         // 이미 존재한다면 업데이트
         Recruitment recruitment = existingRecruitment
@@ -185,10 +193,10 @@ public class RecruitmentService {
         recruitment = recruitmentRepository.save(recruitment);
 
         // 기술 스택 처리를 별도 메서드로 분리
-        processTechStacks(recruitment, requestDTO.getRequiredSkills());
+        processTechStacks(recruitment, new HashSet<>(requestDTO.getRequiredSkills()));
 
         // 태그 처리 추가
-        processTags(recruitment, requestDTO.getTags());
+        processTags(recruitment, new HashSet<>(requestDTO.getTags()));
 
         return recruitment;
     }
@@ -251,9 +259,9 @@ public class RecruitmentService {
 
         // 추가할 기술 스택 생성
         if (!techNamesToAdd.isEmpty()) {
-            List<TechItemRequestDTO> skillsToAdd = newRequiredSkills.stream()
+            Set<TechItemRequestDTO> skillsToAdd = newRequiredSkills.stream()
                     .filter(skill -> techNamesToAdd.contains(skill.getEnglishName()))
-                    .toList();
+                    .collect(Collectors.toSet());
 
             processTechStacks(recruitment, skillsToAdd);
         }
@@ -265,7 +273,7 @@ public class RecruitmentService {
      * 2. 없는 TechItem 생성
      * 3. TechStack 생성 및 저장
      */
-    private void processTechStacks(Recruitment recruitment, List<TechItemRequestDTO> requiredSkills) {
+    private void processTechStacks(Recruitment recruitment, Set<TechItemRequestDTO> requiredSkills) {
         if (requiredSkills == null || requiredSkills.isEmpty()) {
             return;
         }
@@ -293,7 +301,7 @@ public class RecruitmentService {
     /**
      * TechItem을 조회하거나 생성하는 메서드
      */
-    private List<TechItem> getOrCreateTechItems(Set<String> techNames, List<TechItemRequestDTO> requiredSkills) {
+    private List<TechItem> getOrCreateTechItems(Set<String> techNames, Set<TechItemRequestDTO> requiredSkills) {
         // 기존 TechItem 조회
         List<TechItem> existingTechItems = techItemRepository.findAllByEnglishNameIn(techNames);
 
@@ -356,14 +364,14 @@ public class RecruitmentService {
                     .toList();
 
             tagRepository.deleteAllByIdInBatch(tagIdsToRemove);
-            recruitment.getTags().removeAll(tagsToRemove);
+            tagsToRemove.forEach(recruitment.getTags()::remove);
         }
 
         // 추가할 태그 생성
         if (!tagNamesToAdd.isEmpty()) {
-            List<TagRequestDTO> tagsToAdd = newTags.stream()
+            Set<TagRequestDTO> tagsToAdd = newTags.stream()
                     .filter(tag -> tagNamesToAdd.contains(tag.getTagName()))
-                    .toList();
+                    .collect(Collectors.toSet());
 
             processTags(recruitment, tagsToAdd);
         }
@@ -375,7 +383,7 @@ public class RecruitmentService {
      * 2. 없는 TagItem 생성
      * 3. Tag 생성 및 저장
      */
-    private void processTags(Recruitment recruitment, List<TagRequestDTO> tags) {
+    private void processTags(Recruitment recruitment, Set<TagRequestDTO> tags) {
         if (tags == null || tags.isEmpty()) {
             return;
         }
@@ -403,7 +411,7 @@ public class RecruitmentService {
     /**
      * TagItem을 조회하거나 생성하는 메서드
      */
-    private List<TagItem> getOrCreateTagItems(Set<String> tagNames, List<TagRequestDTO> tags) {
+    private List<TagItem> getOrCreateTagItems(Set<String> tagNames, Set<TagRequestDTO> tags) {
         // 기존 TagItem 조회
         List<TagItem> existingTagItems = tagItemRepository.findAllByTagNameIn(tagNames);
 

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
@@ -158,12 +158,12 @@ public class RecruitmentService {
     @Transactional
     public RecruitmentResponseDTO createOrUpdateRecruitment(RecruitmentRequestDTO requestDTO) {
         // 태그 및 기술 스택의 중복 제거 및 정렬
-        Set<TagRequestDTO> uniqueTags = new TreeSet<>(Comparator.comparing(TagRequestDTO::getTagName));
+        Set<TagRequestDTO> uniqueTags = new TreeSet<>();
         if (requestDTO.getTags() != null) {
             uniqueTags.addAll(requestDTO.getTags());
         }
         requestDTO.setTags(new ArrayList<>(uniqueTags));
-        Set<TechItemRequestDTO> uniqueTechItems = new TreeSet<>(Comparator.comparing(TechItemRequestDTO::getEnglishName));
+        Set<TechItemRequestDTO> uniqueTechItems = new TreeSet<>();
         if (requestDTO.getRequiredSkills() != null) {
             uniqueTechItems.addAll(requestDTO.getRequiredSkills());
         }
@@ -173,12 +173,12 @@ public class RecruitmentService {
         // 이미 존재한다면 업데이트
         Recruitment recruitment = existingRecruitment
                 .map((existing) -> updateRecruitment(existing, requestDTO))
-                .orElseGet(() -> createRecruitment(requestDTO));
+                .orElseGet(() -> createRecruitment(requestDTO, uniqueTags, uniqueTechItems));
 
         return RecruitmentResponseDTO.from(recruitment);
     }
 
-    private Recruitment createRecruitment(RecruitmentRequestDTO requestDTO) {
+    private Recruitment createRecruitment(RecruitmentRequestDTO requestDTO, Set<TagRequestDTO> uniqueTags, Set<TechItemRequestDTO> uniqueTechItems) {
         // Company를 먼저 저장 (transient 문제 해결)
         //Company savedCompany = companyRepository.save(requestDTO.getCompany().toEntity());
         Company company = requestDTO.getCompany().toEntity();
@@ -193,10 +193,10 @@ public class RecruitmentService {
         recruitment = recruitmentRepository.save(recruitment);
 
         // 기술 스택 처리를 별도 메서드로 분리
-        processTechStacks(recruitment, new HashSet<>(requestDTO.getRequiredSkills()));
+        processTechStacks(recruitment, uniqueTechItems);
 
         // 태그 처리 추가
-        processTags(recruitment, new HashSet<>(requestDTO.getTags()));
+        processTags(recruitment, uniqueTags);
 
         return recruitment;
     }
@@ -365,6 +365,7 @@ public class RecruitmentService {
 
             tagRepository.deleteAllByIdInBatch(tagIdsToRemove);
             tagsToRemove.forEach(recruitment.getTags()::remove);
+            recruitment.getTags().removeAll(tagsToRemove);
         }
 
         // 추가할 태그 생성

--- a/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
@@ -582,15 +582,15 @@ public class RecruitmentServiceTest {
         // 기술 스택 검증
         assertEquals(2, result.getTechStacks().size());
 
-        TechStackDTO techStackDTO1 = result.getTechStacks().get(0);
-        assertEquals("자바", techStackDTO1.getLabelKo());
-        assertEquals("Java", techStackDTO1.getLabelEn());
-        assertEquals("java_icon.png", techStackDTO1.getIconUrl());
-
-        TechStackDTO techStackDTO2 = result.getTechStacks().get(1);
+        TechStackDTO techStackDTO2 = result.getTechStacks().get(0);
         assertEquals("스프링", techStackDTO2.getLabelKo());
         assertEquals("Spring", techStackDTO2.getLabelEn());
         assertEquals("spring_icon.png", techStackDTO2.getIconUrl());
+
+        TechStackDTO techStackDTO1 = result.getTechStacks().get(1);
+        assertEquals("자바", techStackDTO1.getLabelKo());
+        assertEquals("Java", techStackDTO1.getLabelEn());
+        assertEquals("java_icon.png", techStackDTO1.getIconUrl());
 
         // Repository 호출 검증
         verify(recruitmentRepository).findDetailById(recruitmentId);

--- a/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
@@ -582,15 +582,15 @@ public class RecruitmentServiceTest {
         // 기술 스택 검증
         assertEquals(2, result.getTechStacks().size());
 
-        TechStackDTO techStackDTO2 = result.getTechStacks().get(0);
-        assertEquals("스프링", techStackDTO2.getLabelKo());
-        assertEquals("Spring", techStackDTO2.getLabelEn());
-        assertEquals("spring_icon.png", techStackDTO2.getIconUrl());
-
-        TechStackDTO techStackDTO1 = result.getTechStacks().get(1);
+        TechStackDTO techStackDTO1 = result.getTechStacks().get(0);
         assertEquals("자바", techStackDTO1.getLabelKo());
         assertEquals("Java", techStackDTO1.getLabelEn());
         assertEquals("java_icon.png", techStackDTO1.getIconUrl());
+
+        TechStackDTO techStackDTO2 = result.getTechStacks().get(1);
+        assertEquals("스프링", techStackDTO2.getLabelKo());
+        assertEquals("Spring", techStackDTO2.getLabelEn());
+        assertEquals("spring_icon.png", techStackDTO2.getIconUrl());
 
         // Repository 호출 검증
         verify(recruitmentRepository).findDetailById(recruitmentId);


### PR DESCRIPTION
태그와 기술 스택의 중복을 제거하고 정렬하는 로직을 추가하여 데이터의 일관성을 높였습니다. 또한, 관련 엔티티의 유니크 제약 조건을 추가하여 데이터베이스 무결성을 강화했습니다.

# 🚀 What’s this PR about?

* 태그 및 기술스택에 **유니크 키 설정** 추가
* 태그·기술스택 삽입 시 **TreeSet을 활용한 정렬 및 중복 제거**
* 일부 누락된 **`@Repository` 어노테이션** 추가

# 🛠️ What’s been done?

  * `tag`, `tech_stack` 테이블에 유니크 키 컬럼 추가
  * 중복 데이터 삽입 방지 로직 추가
* **데이터 삽입 로직 개선**

  * `TreeSet`으로 정렬 + 중복 제거 후 DB 저장
* **레포지토리 누락 수정**

  * 누락된 `@Repository` 어노테이션 추가
  * Spring에서 Bean 인식 문제 방지

# 🧪 Testing Details

- **테스트 코드 및 결과:** 작성한 테스트 코드와 주요 테스트 케이스를 설명하고, 통과된 테스트 결과를 요약해 주세요.
  - 테스트 커버리지 및 성공 여부
  - 추가적인 검증이 필요한 시나리오

# 👀 Checkpoints for Reviewers

- **리뷰 시 확인할 사항:**
  - 확인이 필요한 부분 (ex. 코드 스타일, 로직 등)
  - 추가로 논의하고 싶은 주제나 우려 사항
  - 리뷰어의 의견을 듣고 싶은 내용

# 📚 References & Resources

- **참고 자료:** 작업 중 참고한 문서, 코드 스니펫, 블로그, 사이트 등을 링크로 연결해 주세요.
  - 예: 공식 문서, 유용한 Stack Overflow 답변, 팀 내 참고 자료

# 🎯 Related Issues

closes #64 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 회사 설립일에 대한 과거 또는 현재 날짜 검증이 비활성화되었습니다.

* **신규 기능**
  * 태그와 기술 스택의 중복 등록이 방지되며, 정렬된 상태로 저장됩니다.
  * 태그 및 기술 스택의 조합에 대해 중복 저장이 불가능하도록 데이터베이스 제약 조건이 추가되었습니다.

* **기타**
  * 일부 저장소가 Spring Repository로 명확히 표시되었습니다.
  * 태그와 기술 스택 관련 데이터 전송 객체에 객체 비교 및 정렬 기능이 추가되어 일관된 데이터 처리가 가능합니다.
  * 모집 상세 정보에서 태그와 기술 스택 중복 제거 및 정렬이 적용되어 정확한 정보 제공이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->