### PR TITLE
리스트 조회 기능 개선

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/controller/RecruitmentController.java
@@ -12,6 +12,7 @@ import org.example.hugmeexp.domain.recruitment.dto.*;
 import org.example.hugmeexp.domain.recruitment.service.RecruitmentService;
 import org.example.hugmeexp.global.common.response.Response;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -45,13 +46,14 @@ public class RecruitmentController {
     )
     @GetMapping
     public ResponseEntity<Response<List<RecruitmentResponseDTO>>> listRecruitments(
-            @Valid @ModelAttribute RecruitmentSearchConditionDTO conditionDTO) {
+            @Valid @ModelAttribute RecruitmentSearchConditionDTO conditionDTO,
+            @RequestParam(defaultValue = "0") int page){
 
-        List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(conditionDTO);
+        Page<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(conditionDTO, page);
 
         Response<List<RecruitmentResponseDTO>> response = Response.<List<RecruitmentResponseDTO>>builder()
                 .message("채용 공고 목록 조회 성공")
-                .data(result)
+                .data(result.getContent())
                 .build();
 
         return ResponseEntity.status(HttpStatus.OK).body(response);

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/controller/RecruitmentController.java
@@ -32,7 +32,14 @@ public class RecruitmentController {
 
     @Operation(
         summary = "채용 공고 목록 조회",
-        description = "조건에 따라 채용 공고 목록을 조회합니다",
+        description = """
+            채용 목록에서 사용할 수 있는 다양한 필터 조건에 따라 공고를 조회합니다.
+            
+            - 페이징: 한 페이지당 40개, page 파라미터는 0부터 시작
+            - 마감일이 지난 공고는 자동 제외됩니다
+            - 수정일(modifiedAt) 기준 최신순 정렬
+            - 경력 조건은 입력값과 겹치는 공고 전부 포함
+            """,
         responses = {
             @ApiResponse(
                 responseCode = "200",

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/controller/RecruitmentController.java
@@ -161,9 +161,12 @@ public class RecruitmentController {
 
     @Operation(
         summary = "채용 공고 필터 옵션 조회",
-        description = "채용 목록에서 사용할 수 있는 필터링 조건들을 조회합니다.\n\n" +
-            "- 학력, 경력, 기술스택, 근무지, 태그, 연봉 범위 포함\n" +
-            "- 프론트 필터 렌더링용 메타 데이터로 활용",
+        description = """
+            채용 목록에서 사용할 수 있는 필터링 조건들을 조회합니다.
+            
+            - 학력, 경력, 기술스택, 근무지, 태그, 연봉 범위 포함
+            - 프론트 필터 렌더링용 메타 데이터로 활용
+            """,
         responses = {
             @ApiResponse(
                 responseCode = "200",

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
@@ -95,6 +95,7 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
         )
         FROM Recruitment r
         JOIN r.company c
+        WHERE r.dueDate > CURRENT_TIMESTAMP
         ORDER BY r.modifiedAt DESC
     """)
     List<RecruitmentResponseDTO> findLatestRecruitments(Pageable pageable);
@@ -128,13 +129,16 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
     @Query("""
         SELECT r FROM Recruitment r
         JOIN FETCH r.company c
-        WHERE LOWER(r.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
-        OR LOWER(c.companyName) LIKE LOWER(CONCAT('%', :keyword, '%'))
+        WHERE r.dueDate > CURRENT_TIMESTAMP AND (
+            LOWER(r.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
+            OR LOWER(c.companyName) LIKE LOWER(CONCAT('%', :keyword, '%'))
+        )
     """)
     List<Recruitment> findByKeyword(@Param("keyword") String keyword, Pageable pageable);
 
 
-    boolean existsByRecruitmentSourceId(String recruitmentSourceId);
+
+
 
     @Query("SELECT r FROM Recruitment r " +
             "LEFT JOIN FETCH r.techStacks ts " +

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
@@ -68,7 +68,7 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
                     (:#{#cond.experienceMin} IS NULL OR :#{#cond.experienceMax} IS NULL)
                      OR
                      (r.experienceMax >= :#{#cond.experienceMin} AND r.experienceMin <= :#{#cond.experienceMax})
-                ) AND                                                                      
+                ) AND
                 (:#{#cond.education} IS NULL OR r.education = :#{#cond.education}) AND
                 (:#{#cond.workLocation} IS NULL OR r.workLocation LIKE %:#{#cond.workLocation}%) AND
                 (:#{#cond.topLeftLat} IS NULL OR r.latitude >= :#{#cond.topLeftLat}) AND

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
@@ -3,6 +3,7 @@ package org.example.hugmeexp.domain.recruitment.repository;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO;
 import org.example.hugmeexp.domain.recruitment.dto.RecruitmentSearchConditionDTO;
 import org.example.hugmeexp.domain.recruitment.entity.Recruitment;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -16,39 +17,68 @@ import java.util.Optional;
 public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> {
 
     /**
-     * 검색 조건에 맞는 채용 공고 목록을 조회합니다.
-     * 조건에 따라 필터링된 결과를 반환합니다.
+     * 채용 공고 목록을 조회합니다.
+     * 조건에 따라 필터링된 채용 공고를 페이지 단위로 반환합니다.
      *
      * @param cond 검색 조건 DTO
-     * @return 채용 공고 목록
+     * @param pageable 페이징 정보
+     * @return 필터링된 채용 공고 목록 (RecruitmentResponseDTO)
      */
-    @Query("""
-        SELECT new org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO(
-            r.id, r.recruitmentSourceId, r.title, c.companyName, c.companyImageUrl, r.dueDate,
-            r.experienceMin, r.experienceMax, r.workLocation, r.latitude, r.longitude, r.modifiedAt
-        )
-        FROM Recruitment r
-        JOIN r.company c
-        LEFT JOIN r.techStacks ts
-        LEFT JOIN r.tags t
-        WHERE (:#{#cond.salaryMin} IS NULL OR r.salaryMin >= :#{#cond.salaryMin}) AND
-              (:#{#cond.salaryMax} IS NULL OR r.salaryMax <= :#{#cond.salaryMax}) AND
-              (:#{#cond.experienceMin} IS NULL OR r.experienceMin <= :#{#cond.experienceMin}) AND
-              (:#{#cond.experienceMax} IS NULL OR r.experienceMax >= :#{#cond.experienceMax}) AND
-              (:#{#cond.education} IS NULL OR r.education = :#{#cond.education}) AND
-              (:#{#cond.workLocation} IS NULL OR r.workLocation LIKE %:#{#cond.workLocation}%) AND
-              (:#{#cond.topLeftLat} IS NULL OR r.latitude >= :#{#cond.topLeftLat}) AND
-              (:#{#cond.topLeftLng} IS NULL OR r.longitude >= :#{#cond.topLeftLng}) AND
-              (:#{#cond.bottomRightLat} IS NULL OR r.latitude <= :#{#cond.bottomRightLat}) AND
-              (:#{#cond.bottomRightLng} IS NULL OR r.longitude <= :#{#cond.bottomRightLng}) AND
-              (:#{#cond.techStacks} IS NULL OR ts.id IN :#{#cond.techStacks}) AND
-              (:#{#cond.tags} IS NULL OR t.id IN :#{#cond.tags})
-        GROUP BY r.id, r.recruitmentSourceId, r.title, c.companyName, c.companyImageUrl, r.dueDate,
-                 r.experienceMin, r.experienceMax, r.workLocation, r.latitude, r.longitude, r.modifiedAt
-        HAVING (:#{#cond.techStacks} IS NULL OR COUNT(DISTINCT ts.id) = :#{#cond.techStackCount}) AND
-               (:#{#cond.tags} IS NULL OR COUNT(DISTINCT t.id) = :#{#cond.tagCount})
+    @Query(
+        value = """
+            SELECT new org.example.hugmeexp.domain.recruitment.dto.RecruitmentResponseDTO(
+                r.id, r.recruitmentSourceId, r.title, c.companyName, c.companyImageUrl, r.dueDate,
+                r.experienceMin, r.experienceMax, r.workLocation, r.latitude, r.longitude, r.modifiedAt
+            )
+            FROM Recruitment r
+            JOIN r.company c
+            LEFT JOIN r.techStacks ts
+            LEFT JOIN r.tags t
+            WHERE r.dueDate > CURRENT_TIMESTAMP AND
+                (:#{#cond.salaryMin} IS NULL OR r.salaryMin >= :#{#cond.salaryMin}) AND
+                (:#{#cond.salaryMax} IS NULL OR r.salaryMax <= :#{#cond.salaryMax}) AND
+                (
+                  (:#{#cond.experienceMin} IS NULL OR :#{#cond.experienceMax} IS NULL)
+                  OR
+                  (r.experienceMax >= :#{#cond.experienceMin} AND r.experienceMin <= :#{#cond.experienceMax})
+                ) AND
+                (:#{#cond.education} IS NULL OR r.education = :#{#cond.education}) AND
+                (:#{#cond.workLocation} IS NULL OR r.workLocation LIKE %:#{#cond.workLocation}%) AND
+                (:#{#cond.topLeftLat} IS NULL OR r.latitude >= :#{#cond.topLeftLat}) AND
+                (:#{#cond.topLeftLng} IS NULL OR r.longitude >= :#{#cond.topLeftLng}) AND
+                (:#{#cond.bottomRightLat} IS NULL OR r.latitude <= :#{#cond.bottomRightLat}) AND
+                (:#{#cond.bottomRightLng} IS NULL OR r.longitude <= :#{#cond.bottomRightLng}) AND
+                (:#{#cond.techStacks} IS NULL OR ts.id IN :#{#cond.techStacks}) AND
+                (:#{#cond.tags} IS NULL OR t.id IN :#{#cond.tags})
+            GROUP BY r.id, r.recruitmentSourceId, r.title, c.companyName, c.companyImageUrl, r.dueDate,
+                r.experienceMin, r.experienceMax, r.workLocation, r.latitude, r.longitude, r.modifiedAt
+            HAVING (:#{#cond.techStacks} IS NULL OR COUNT(DISTINCT ts.id) = :#{#cond.techStackCount}) AND
+                (:#{#cond.tags} IS NULL OR COUNT(DISTINCT t.id) = :#{#cond.tagCount})
+            ORDER BY r.modifiedAt DESC
+            """,
+        countQuery = """
+            SELECT COUNT(DISTINCT r.id)
+            FROM Recruitment r
+            LEFT JOIN r.techStacks ts
+            LEFT JOIN r.tags t
+            WHERE r.dueDate > CURRENT_TIMESTAMP AND
+                (:#{#cond.salaryMin} IS NULL OR r.salaryMin >= :#{#cond.salaryMin}) AND
+                (:#{#cond.salaryMax} IS NULL OR r.salaryMax <= :#{#cond.salaryMax}) AND
+                (
+                    (:#{#cond.experienceMin} IS NULL OR :#{#cond.experienceMax} IS NULL)
+                     OR
+                     (r.experienceMax >= :#{#cond.experienceMin} AND r.experienceMin <= :#{#cond.experienceMax})
+                ) AND                                                                      
+                (:#{#cond.education} IS NULL OR r.education = :#{#cond.education}) AND
+                (:#{#cond.workLocation} IS NULL OR r.workLocation LIKE %:#{#cond.workLocation}%) AND
+                (:#{#cond.topLeftLat} IS NULL OR r.latitude >= :#{#cond.topLeftLat}) AND
+                (:#{#cond.topLeftLng} IS NULL OR r.longitude >= :#{#cond.topLeftLng}) AND
+                (:#{#cond.bottomRightLat} IS NULL OR r.latitude <= :#{#cond.bottomRightLat}) AND
+                (:#{#cond.bottomRightLng} IS NULL OR r.longitude <= :#{#cond.bottomRightLng}) AND
+                (:#{#cond.techStacks} IS NULL OR ts.id IN :#{#cond.techStacks}) AND
+                (:#{#cond.tags} IS NULL OR t.id IN :#{#cond.tags})
     """)
-    List<RecruitmentResponseDTO> findBySearchConditions(@Param("cond") RecruitmentSearchConditionDTO cond);
+    Page<RecruitmentResponseDTO> findBySearchConditions(@Param("cond") RecruitmentSearchConditionDTO cond, Pageable pageable);
 
 
     /**

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
@@ -56,10 +56,11 @@ public class RecruitmentService {
 
     /**
      * 채용 공고 목록을 조회합니다.
-     * 검색 조건에 따라 필터링된 채용 공고 목록을 반환합니다.
+     * 검색 조건에 따라 필터링된 채용 공고를 페이지 단위로 반환합니다.
      *
      * @param cond 검색 조건 DTO
-     * @return 채용 공고 목록
+     * @param page 페이지 번호 (0부터 시작)
+     * @return 필터링된 채용 공고 목록 (RecruitmentResponseDTO)
      */
     public Page<RecruitmentResponseDTO> listRecruitments(RecruitmentSearchConditionDTO cond, int page) {
         RecruitmentSearchConditionDTO enrichedCond = cond.toBuilder()

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
@@ -19,6 +19,7 @@ import org.example.hugmeexp.domain.recruitment.repository.TechStackRepository;
 import org.example.hugmeexp.domain.recruitment.repository.TagRepository;
 import org.example.hugmeexp.domain.recruitment.repository.CompanyRepository;
 import org.example.hugmeexp.global.common.exception.BaseCustomException;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -62,7 +63,7 @@ public class RecruitmentService {
      * @param cond 검색 조건 DTO
      * @return 채용 공고 목록
      */
-    public List<RecruitmentResponseDTO> listRecruitments(RecruitmentSearchConditionDTO cond) {
+    public Page<RecruitmentResponseDTO> listRecruitments(RecruitmentSearchConditionDTO cond, int page) {
         RecruitmentSearchConditionDTO enrichedCond = cond.toBuilder()
                 .techStacks((cond.getTechStacks() == null || cond.getTechStacks().isEmpty()) ? null : cond.getTechStacks())
                 .tags((cond.getTags() == null || cond.getTags().isEmpty()) ? null : cond.getTags())
@@ -70,7 +71,9 @@ public class RecruitmentService {
                 .tagCount((cond.getTags() == null || cond.getTags().isEmpty()) ? null : (long) cond.getTags().size())
                 .build();
 
-        return recruitmentRepository.findBySearchConditions(enrichedCond);
+        Pageable pageable = PageRequest.of(page, 40);
+
+        return recruitmentRepository.findBySearchConditions(enrichedCond, pageable);
     }
 
     /**

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
@@ -18,11 +18,9 @@ import org.example.hugmeexp.domain.recruitment.repository.TechItemRepository;
 import org.example.hugmeexp.domain.recruitment.repository.TechStackRepository;
 import org.example.hugmeexp.domain.recruitment.repository.TagRepository;
 import org.example.hugmeexp.domain.recruitment.repository.CompanyRepository;
-import org.example.hugmeexp.global.common.exception.BaseCustomException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
@@ -204,18 +206,22 @@ public class RecruitmentServiceTest {
                 .bottomRightLng(new BigDecimal("127.0"))
                 .build();
 
-        List<RecruitmentResponseDTO> expectedResult = createMockResponseList();
-        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class))).thenReturn(expectedResult);
+        int page = 0;
+        List<RecruitmentResponseDTO> expectedContent = createMockResponseList();
+        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 40);
+
+        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
+            .thenReturn(expectedPage);
 
         // When
-        List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition);
+        Page<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition, page);
 
         // Then
-        assertEquals(expectedResult, result);
-        verify(recruitmentRepository).findBySearchConditions(argThat(cond ->
-            cond.getTechStackCount() == 2L &&
-            cond.getTagCount() == 2L
-        ));
+        assertEquals(expectedPage.getContent(), result.getContent());
+        verify(recruitmentRepository).findBySearchConditions(
+            argThat(cond -> cond.getTechStackCount() == 2L && cond.getTagCount() == 2L),
+            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 40)
+        );
     }
 
     @Test
@@ -224,15 +230,22 @@ public class RecruitmentServiceTest {
         // Given
         RecruitmentSearchConditionDTO condition = RecruitmentSearchConditionDTO.builder().build();
 
-        List<RecruitmentResponseDTO> expectedResult = createMockResponseList();
-        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class))).thenReturn(expectedResult);
+        int page = 0;
+        List<RecruitmentResponseDTO> expectedContent = createMockResponseList();
+        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 40);
+
+        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
+            .thenReturn(expectedPage);
 
         // When
-        List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition);
+        Page<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition, page);
 
         // Then
-        assertEquals(expectedResult, result);
-        verify(recruitmentRepository).findBySearchConditions(any(RecruitmentSearchConditionDTO.class));
+        assertEquals(expectedPage.getContent(), result.getContent());
+        verify(recruitmentRepository).findBySearchConditions(
+            any(RecruitmentSearchConditionDTO.class),
+            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 40)
+        );
     }
 
     @Test
@@ -246,15 +259,22 @@ public class RecruitmentServiceTest {
                 .experienceMax(5)
                 .build();
 
-        List<RecruitmentResponseDTO> expectedResult = createMockResponseList();
-        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class))).thenReturn(expectedResult);
+        int page = 0;
+        List<RecruitmentResponseDTO> expectedContent = createMockResponseList();
+        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 40);
+
+        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
+            .thenReturn(expectedPage);
 
         // When
-        List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition);
+        Page<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition, page);
 
         // Then
-        assertEquals(expectedResult, result);
-        verify(recruitmentRepository).findBySearchConditions(any(RecruitmentSearchConditionDTO.class));
+        assertEquals(expectedPage.getContent(), result.getContent());
+        verify(recruitmentRepository).findBySearchConditions(
+            any(RecruitmentSearchConditionDTO.class),
+            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 40)
+        );
     }
 
     @Test
@@ -270,18 +290,22 @@ public class RecruitmentServiceTest {
                 .tags(null)
                 .build();
 
-        List<RecruitmentResponseDTO> expectedResult = createMockResponseList();
-        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class))).thenReturn(expectedResult);
+        int page = 0;
+        List<RecruitmentResponseDTO> expectedContent = createMockResponseList();
+        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 40);
+
+        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
+            .thenReturn(expectedPage);
 
         // When
-        List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition);
+        Page<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition, page);
 
         // Then
-        assertEquals(expectedResult, result);
-        verify(recruitmentRepository).findBySearchConditions(argThat(cond ->
-            cond.getTechStackCount() == null &&
-            cond.getTagCount() == null
-        ));
+        assertEquals(expectedPage.getContent(), result.getContent());
+        verify(recruitmentRepository).findBySearchConditions(
+            argThat(cond -> cond.getTechStackCount() == null && cond.getTagCount() == null),
+            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 40)
+        );
     }
 
     @Test
@@ -293,18 +317,22 @@ public class RecruitmentServiceTest {
                 .tags(List.of())
                 .build();
 
-        List<RecruitmentResponseDTO> expectedResult = createMockResponseList();
-        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class))).thenReturn(expectedResult);
+        int page = 0;
+        List<RecruitmentResponseDTO> expectedContent = createMockResponseList();
+        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 40);
+
+        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
+            .thenReturn(expectedPage);
 
         // When
-        List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition);
+        Page<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition, page);
 
         // Then
-        assertEquals(expectedResult, result);
-        verify(recruitmentRepository).findBySearchConditions(argThat(cond ->
-            cond.getTechStackCount() == null &&
-            cond.getTagCount() == null
-        ));
+        assertEquals(expectedPage.getContent(), result.getContent());
+        verify(recruitmentRepository).findBySearchConditions(
+            argThat(cond -> cond.getTechStackCount() == null && cond.getTagCount() == null),
+            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 40)
+        );
     }
 
     @Test
@@ -316,15 +344,22 @@ public class RecruitmentServiceTest {
                 .tags(null)
                 .build();
 
-        List<RecruitmentResponseDTO> expectedResult = createMockResponseList();
-        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class))).thenReturn(expectedResult);
+        int page = 0;
+        List<RecruitmentResponseDTO> expectedContent = createMockResponseList();
+        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 40);
+
+        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
+            .thenReturn(expectedPage);
 
         // When
-        List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition);
+        Page<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition, page);
 
         // Then
-        assertEquals(expectedResult, result);
-        verify(recruitmentRepository).findBySearchConditions(any(RecruitmentSearchConditionDTO.class));
+        assertEquals(expectedPage.getContent(), result.getContent());
+        verify(recruitmentRepository).findBySearchConditions(
+            argThat(cond -> cond.getTechStackCount() == 3L && cond.getTagCount() == null),
+            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 40)
+        );
     }
 
     @Test
@@ -336,15 +371,236 @@ public class RecruitmentServiceTest {
                 .tags(List.of(1L, 2L))
                 .build();
 
-        List<RecruitmentResponseDTO> expectedResult = createMockResponseList();
-        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class))).thenReturn(expectedResult);
+        int page = 0;
+        List<RecruitmentResponseDTO> expectedContent = createMockResponseList();
+        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 40);
+
+        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
+            .thenReturn(expectedPage);
 
         // When
-        List<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition);
+        Page<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition, page);
 
         // Then
-        assertEquals(expectedResult, result);
-        verify(recruitmentRepository).findBySearchConditions(any(RecruitmentSearchConditionDTO.class));
+        assertEquals(expectedPage.getContent(), result.getContent());
+        verify(recruitmentRepository).findBySearchConditions(
+            argThat(cond -> cond.getTechStackCount() == null && cond.getTagCount() == 2L),
+            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 40)
+        );
+    }
+
+    @Test
+    @DisplayName("채용 공고 목록 조회 - 페이지네이션 테스트 (40개 항목)")
+    void listRecruitments_ShouldReturnPageWith40Items() {
+        // Given
+        RecruitmentSearchConditionDTO condition = RecruitmentSearchConditionDTO.builder().build();
+        int page = 0;
+
+        // 50개의 아이템을 생성 (40개만 반환되어야 함)
+        List<RecruitmentResponseDTO> mockItems = new ArrayList<>();
+        for (int i = 1; i <= 50; i++) {
+            mockItems.add(new RecruitmentResponseDTO(
+                (long) i, "test::" + i, "개발자 모집 " + i, "회사 " + i, "image_" + i + ".jpg",
+                LocalDateTime.now().plusDays(30), // 만료되지 않은 공고
+                2, 5, "서울시", new BigDecimal("37.5"), new BigDecimal("127.0"),
+                LocalDateTime.now().minusDays(i) // 최신순으로 정렬되도록 설정
+            ));
+        }
+
+        // 첫 페이지에는 40개의 아이템만 포함되어야 함
+        Page<RecruitmentResponseDTO> mockPage = new PageImpl<>(
+            mockItems.subList(0, 40), 
+            PageRequest.of(page, 40), 
+            mockItems.size()
+        );
+
+        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
+            .thenReturn(mockPage);
+
+        // When
+        Page<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition, page);
+
+        // Then
+        assertEquals(40, result.getContent().size()); // 페이지당 40개 항목
+        assertEquals(50, result.getTotalElements()); // 전체 50개 항목
+        assertEquals(2, result.getTotalPages()); // 총 2페이지 (40 + 10)
+        verify(recruitmentRepository).findBySearchConditions(
+            any(RecruitmentSearchConditionDTO.class),
+            argThat(pageable -> pageable.getPageSize() == 40)
+        );
+    }
+
+    @Test
+    @DisplayName("채용 공고 목록 조회 - 최신순 정렬 테스트")
+    void listRecruitments_ShouldReturnSortedByModifiedAtDesc() {
+        // Given
+        RecruitmentSearchConditionDTO condition = RecruitmentSearchConditionDTO.builder().build();
+        int page = 0;
+
+        // 여러 날짜의 수정일을 가진 아이템 생성
+        List<RecruitmentResponseDTO> mockItems = new ArrayList<>();
+        for (int i = 1; i <= 10; i++) {
+            mockItems.add(new RecruitmentResponseDTO(
+                (long) i, "test::" + i, "개발자 모집 " + i, "회사 " + i, "image_" + i + ".jpg",
+                LocalDateTime.now().plusDays(30),
+                2, 5, "서울시", new BigDecimal("37.5"), new BigDecimal("127.0"),
+                LocalDateTime.now().minusDays(i) // 최신순으로 정렬되도록 설정
+            ));
+        }
+
+        Page<RecruitmentResponseDTO> mockPage = createMockResponsePage(mockItems, page, 40);
+        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
+            .thenReturn(mockPage);
+
+        // When
+        Page<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition, page);
+
+        // Then
+        List<RecruitmentResponseDTO> content = result.getContent();
+
+        // 결과가 수정일 기준 내림차순으로 정렬되어 있는지 확인
+        for (int i = 0; i < content.size() - 1; i++) {
+            LocalDateTime current = content.get(i).getModifiedAt();
+            LocalDateTime next = content.get(i + 1).getModifiedAt();
+            assertTrue(current.isAfter(next) || current.isEqual(next), 
+                    "결과는 수정일 기준 내림차순으로 정렬되어야 합니다");
+        }
+    }
+
+    @Test
+    @DisplayName("채용 공고 목록 조회 - 만료된 공고 제외 테스트")
+    void listRecruitments_ShouldExcludeExpiredRecruitments() {
+        // Given
+        RecruitmentSearchConditionDTO condition = RecruitmentSearchConditionDTO.builder().build();
+        int page = 0;
+
+        // 만료된 공고와 유효한 공고를 모두 포함하는 목록 생성
+        List<RecruitmentResponseDTO> allItems = new ArrayList<>();
+
+        // 만료된 공고 (dueDate가 현재보다 이전)
+        for (int i = 1; i <= 5; i++) {
+            allItems.add(new RecruitmentResponseDTO(
+                (long) i, "expired::" + i, "만료된 공고 " + i, "회사 " + i, "image_" + i + ".jpg",
+                LocalDateTime.now().minusDays(i), // 만료된 공고
+                2, 5, "서울시", new BigDecimal("37.5"), new BigDecimal("127.0"),
+                LocalDateTime.now().minusDays(30)
+            ));
+        }
+
+        // 유효한 공고 (dueDate가 현재보다 이후)
+        List<RecruitmentResponseDTO> validItems = new ArrayList<>();
+        for (int i = 6; i <= 10; i++) {
+            RecruitmentResponseDTO validItem = new RecruitmentResponseDTO(
+                (long) i, "valid::" + i, "유효한 공고 " + i, "회사 " + i, "image_" + i + ".jpg",
+                LocalDateTime.now().plusDays(i), // 유효한 공고
+                2, 5, "서울시", new BigDecimal("37.5"), new BigDecimal("127.0"),
+                LocalDateTime.now().minusDays(i)
+            );
+            allItems.add(validItem);
+            validItems.add(validItem);
+        }
+
+        // 레포지토리는 이미 만료된 공고를 필터링한 결과를 반환해야 함
+        Page<RecruitmentResponseDTO> mockPage = createMockResponsePage(validItems, page, 40);
+        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
+            .thenReturn(mockPage);
+
+        // When
+        Page<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition, page);
+
+        // Then
+        assertEquals(5, result.getContent().size()); // 유효한 공고만 5개
+
+        // 모든 공고의 dueDate가 현재 시간 이후인지 확인
+        LocalDateTime now = LocalDateTime.now();
+        for (RecruitmentResponseDTO item : result.getContent()) {
+            assertTrue(item.getDueDate().isAfter(now), 
+                    "모든 공고는 현재 시간 이후의 dueDate를 가져야 합니다");
+            assertTrue(item.getRecruitmentSourceId().startsWith("valid::"), 
+                    "모든 공고는 유효한 공고여야 합니다");
+        }
+    }
+
+    @Test
+    @DisplayName("채용 공고 목록 조회 - 경력 범위 필터링 테스트")
+    void listRecruitments_ShouldFilterByExperienceRange() {
+        // Given
+        // 경력 범위 3-5년으로 검색 조건 설정
+        RecruitmentSearchConditionDTO condition = RecruitmentSearchConditionDTO.builder()
+                .experienceMin(3)
+                .experienceMax(5)
+                .build();
+        int page = 0;
+
+        // 다양한 경력 범위를 가진 공고 생성
+        List<RecruitmentResponseDTO> allItems = new ArrayList<>();
+
+        // 1. 경력 범위가 1-2년 (조건에 맞지 않음)
+        allItems.add(new RecruitmentResponseDTO(
+            1L, "exp::1", "경력 1-2년 공고", "회사 1", "image_1.jpg",
+            LocalDateTime.now().plusDays(30),
+            1, 2, "서울시", new BigDecimal("37.5"), new BigDecimal("127.0"),
+            LocalDateTime.now().minusDays(1)
+        ));
+
+        // 2. 경력 범위가 2-4년 (조건과 겹침 - 포함되어야 함)
+        RecruitmentResponseDTO overlapping1 = new RecruitmentResponseDTO(
+            2L, "exp::2", "경력 2-4년 공고", "회사 2", "image_2.jpg",
+            LocalDateTime.now().plusDays(30),
+            2, 4, "서울시", new BigDecimal("37.5"), new BigDecimal("127.0"),
+            LocalDateTime.now().minusDays(2)
+        );
+        allItems.add(overlapping1);
+
+        // 3. 경력 범위가 3-5년 (조건과 정확히 일치 - 포함되어야 함)
+        RecruitmentResponseDTO exact = new RecruitmentResponseDTO(
+            3L, "exp::3", "경력 3-5년 공고", "회사 3", "image_3.jpg",
+            LocalDateTime.now().plusDays(30),
+            3, 5, "서울시", new BigDecimal("37.5"), new BigDecimal("127.0"),
+            LocalDateTime.now().minusDays(3)
+        );
+        allItems.add(exact);
+
+        // 4. 경력 범위가 4-6년 (조건과 겹침 - 포함되어야 함)
+        RecruitmentResponseDTO overlapping2 = new RecruitmentResponseDTO(
+            4L, "exp::4", "경력 4-6년 공고", "회사 4", "image_4.jpg",
+            LocalDateTime.now().plusDays(30),
+            4, 6, "서울시", new BigDecimal("37.5"), new BigDecimal("127.0"),
+            LocalDateTime.now().minusDays(4)
+        );
+        allItems.add(overlapping2);
+
+        // 5. 경력 범위가 6-8년 (조건에 맞지 않음)
+        allItems.add(new RecruitmentResponseDTO(
+            5L, "exp::5", "경력 6-8년 공고", "회사 5", "image_5.jpg",
+            LocalDateTime.now().plusDays(30),
+            6, 8, "서울시", new BigDecimal("37.5"), new BigDecimal("127.0"),
+            LocalDateTime.now().minusDays(5)
+        ));
+
+        // 조건에 맞는 공고만 포함하는 리스트
+        List<RecruitmentResponseDTO> matchingItems = List.of(overlapping1, exact, overlapping2);
+
+        // 레포지토리는 이미 경력 범위로 필터링한 결과를 반환해야 함
+        Page<RecruitmentResponseDTO> mockPage = createMockResponsePage(matchingItems, page, 40);
+        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
+            .thenReturn(mockPage);
+
+        // When
+        Page<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition, page);
+
+        // Then
+        assertEquals(3, result.getContent().size()); // 조건에 맞는 공고 3개
+
+        // 모든 공고가 경력 범위 조건과 겹치는지 확인
+        for (RecruitmentResponseDTO item : result.getContent()) {
+            boolean rangeOverlaps = 
+                (item.getExperienceMax() >= condition.getExperienceMin() && 
+                 item.getExperienceMin() <= condition.getExperienceMax());
+
+            assertTrue(rangeOverlaps, 
+                    "모든 공고는 경력 범위 조건과 겹쳐야 합니다");
+        }
     }
 
     @Test
@@ -367,7 +623,7 @@ public class RecruitmentServiceTest {
             LocalDateTime current = result.get(i).getModifiedAt();
             LocalDateTime next = result.get(i + 1).getModifiedAt();
             assertTrue(current.isAfter(next) || current.isEqual(next), 
-                    "Results should be sorted by modifiedAt in descending order");
+                    "결과는 수정일 기준 내림차순으로 정렬되어야 합니다");
         }
     }
 
@@ -392,6 +648,11 @@ public class RecruitmentServiceTest {
         ));
 
         return responses;
+    }
+
+    // 테스트용 Page 객체 생성 헬퍼 메소드
+    private Page<RecruitmentResponseDTO> createMockResponsePage(List<RecruitmentResponseDTO> content, int page, int size) {
+        return new PageImpl<>(content, PageRequest.of(page, size), content.size());
     }
 
     // 수정일 기준 내림차순으로 정렬된 테스트용 응답 DTO 리스트 생성 헬퍼 메소드


### PR DESCRIPTION
# 🚀 What’s this PR about?

- 마감일이 지난 공고가 더 이상 조회되지 않도록 필터 추가
- 경력 필터 조건 수정 (요구 경력 범위가 겹치는 공고도 포함되도록)
- 리스트 40개씩 페이징 처리

# 🛠️ What’s been done?

- RecruitmentRepository의 주요 JPQL 쿼리에 r.dueDate > CURRENT_TIMESTAMP 조건 추가
- 기존 경력 필터링 조건에서 유연한 범위 필터링 적용

# 🧪 Testing Details

- 기존 RecruitmentServiceTest에서 페이징 및 필터링 테스트 커버리지 확인
- 마감일이 지난 더미 데이터가 리스트에서 제외되는지 확인
- 경력 조건이 겹치는 공고도 정상적으로 포함되는지 검증

# 👀 Checkpoints for Reviewers


# 📚 References & Resources


# 🎯 Related Issues
- close#66 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 채용 목록 조회 API에 페이지네이션 기능이 추가되어, 한 번에 최대 40개의 채용 공고를 페이지별로 확인할 수 있습니다.
  * 만료된 채용 공고는 자동으로 제외되며, 최근 수정일 기준 내림차순 정렬 및 경력 조건 필터링이 적용됩니다.

* **버그 수정**
  * 만료된 채용 공고가 목록에 노출되지 않도록 개선되었습니다.

* **문서화**
  * 채용 목록 및 필터 조회 API의 설명이 페이지네이션, 정렬, 필터링 동작을 명확히 안내하도록 보강되었습니다.

* **테스트**
  * 페이지네이션, 정렬, 만료 공고 제외, 경력 조건 필터링 등 신규 동작을 검증하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->