### PR TITLE
필터 조건 기능 수정

### DIFF
--- a/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentSearchConditionDTO.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/dto/RecruitmentSearchConditionDTO.java
@@ -28,4 +28,6 @@ public class RecruitmentSearchConditionDTO {
     private Long techStackCount;
     private Long tagCount;
 
+    private String keyword;
+
 }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
@@ -43,13 +43,13 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
                   (r.experienceMax >= :#{#cond.experienceMin} AND r.experienceMin <= :#{#cond.experienceMax})
                 ) AND
                 (:#{#cond.education} IS NULL OR r.education = :#{#cond.education}) AND
-                (:#{#cond.workLocation} IS NULL OR r.workLocation LIKE %:#{#cond.workLocation}%) AND
+                (:#{#cond.workLocation} IS NULL OR r.workLocation LIKE CONCAT('%', :#{#cond.workLocation}, '%')) AND
                 (:#{#cond.topLeftLat} IS NULL OR r.latitude >= :#{#cond.topLeftLat}) AND
                 (:#{#cond.topLeftLng} IS NULL OR r.longitude >= :#{#cond.topLeftLng}) AND
                 (:#{#cond.bottomRightLat} IS NULL OR r.latitude <= :#{#cond.bottomRightLat}) AND
                 (:#{#cond.bottomRightLng} IS NULL OR r.longitude <= :#{#cond.bottomRightLng}) AND
-                (:#{#cond.techStacks} IS NULL OR ts.id IN :#{#cond.techStacks}) AND
-                (:#{#cond.tags} IS NULL OR t.id IN :#{#cond.tags})
+                (:#{#cond.techStacks} IS NULL OR ts.techItem.id IN :#{#cond.techStacks}) AND
+                (:#{#cond.tags} IS NULL OR t.tagItem.id IN :#{#cond.tags})
             GROUP BY r.id, r.recruitmentSourceId, r.title, c.companyName, c.companyImageUrl, r.dueDate,
                 r.experienceMin, r.experienceMax, r.workLocation, r.latitude, r.longitude, r.modifiedAt
             HAVING (:#{#cond.techStacks} IS NULL OR COUNT(DISTINCT ts.id) = :#{#cond.techStackCount}) AND
@@ -70,13 +70,13 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
                      (r.experienceMax >= :#{#cond.experienceMin} AND r.experienceMin <= :#{#cond.experienceMax})
                 ) AND
                 (:#{#cond.education} IS NULL OR r.education = :#{#cond.education}) AND
-                (:#{#cond.workLocation} IS NULL OR r.workLocation LIKE %:#{#cond.workLocation}%) AND
+                (:#{#cond.workLocation} IS NULL OR r.workLocation LIKE CONCAT('%', :#{#cond.workLocation}, '%')) AND
                 (:#{#cond.topLeftLat} IS NULL OR r.latitude >= :#{#cond.topLeftLat}) AND
                 (:#{#cond.topLeftLng} IS NULL OR r.longitude >= :#{#cond.topLeftLng}) AND
                 (:#{#cond.bottomRightLat} IS NULL OR r.latitude <= :#{#cond.bottomRightLat}) AND
                 (:#{#cond.bottomRightLng} IS NULL OR r.longitude <= :#{#cond.bottomRightLng}) AND
-                (:#{#cond.techStacks} IS NULL OR ts.id IN :#{#cond.techStacks}) AND
-                (:#{#cond.tags} IS NULL OR t.id IN :#{#cond.tags})
+                (:#{#cond.techStacks} IS NULL OR ts.techItem.id IN :#{#cond.techStacks}) AND
+                (:#{#cond.tags} IS NULL OR t.tagItem.id IN :#{#cond.tags})
     """)
     Page<RecruitmentResponseDTO> findBySearchConditions(@Param("cond") RecruitmentSearchConditionDTO cond, Pageable pageable);
 

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/repository/RecruitmentRepository.java
@@ -49,7 +49,10 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
                 (:#{#cond.bottomRightLat} IS NULL OR r.latitude <= :#{#cond.bottomRightLat}) AND
                 (:#{#cond.bottomRightLng} IS NULL OR r.longitude <= :#{#cond.bottomRightLng}) AND
                 (:#{#cond.techStacks} IS NULL OR ts.techItem.id IN :#{#cond.techStacks}) AND
-                (:#{#cond.tags} IS NULL OR t.tagItem.id IN :#{#cond.tags})
+                (:#{#cond.tags} IS NULL OR t.tagItem.id IN :#{#cond.tags}) AND
+                (:#{#cond.keyword} IS NULL OR
+                    LOWER(r.title) LIKE LOWER(CONCAT('%', :#{#cond.keyword}, '%')) OR
+                    LOWER(c.companyName) LIKE LOWER(CONCAT('%', :#{#cond.keyword}, '%')))
             GROUP BY r.id, r.recruitmentSourceId, r.title, c.companyName, c.companyImageUrl, r.dueDate,
                 r.experienceMin, r.experienceMax, r.workLocation, r.latitude, r.longitude, r.modifiedAt
             HAVING (:#{#cond.techStacks} IS NULL OR COUNT(DISTINCT ts.id) = :#{#cond.techStackCount}) AND
@@ -59,6 +62,7 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
         countQuery = """
             SELECT COUNT(DISTINCT r.id)
             FROM Recruitment r
+            JOIN r.company c
             LEFT JOIN r.techStacks ts
             LEFT JOIN r.tags t
             WHERE r.dueDate > CURRENT_TIMESTAMP AND
@@ -76,7 +80,10 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
                 (:#{#cond.bottomRightLat} IS NULL OR r.latitude <= :#{#cond.bottomRightLat}) AND
                 (:#{#cond.bottomRightLng} IS NULL OR r.longitude <= :#{#cond.bottomRightLng}) AND
                 (:#{#cond.techStacks} IS NULL OR ts.techItem.id IN :#{#cond.techStacks}) AND
-                (:#{#cond.tags} IS NULL OR t.tagItem.id IN :#{#cond.tags})
+                (:#{#cond.tags} IS NULL OR t.tagItem.id IN :#{#cond.tags}) AND
+                (:#{#cond.keyword} IS NULL OR
+                    LOWER(r.title) LIKE LOWER(CONCAT('%', :#{#cond.keyword}, '%')) OR
+                    LOWER(c.companyName) LIKE LOWER(CONCAT('%', :#{#cond.keyword}, '%')))
     """)
     Page<RecruitmentResponseDTO> findBySearchConditions(@Param("cond") RecruitmentSearchConditionDTO cond, Pageable pageable);
 

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
@@ -69,7 +69,7 @@ public class RecruitmentService {
                 .keyword((cond.getKeyword() == null || cond.getKeyword().isBlank()) ? null : cond.getKeyword())
                 .build();
 
-        Pageable pageable = PageRequest.of(page, 40);
+        Pageable pageable = PageRequest.of(page, 80);
 
         return recruitmentRepository.findBySearchConditions(enrichedCond, pageable);
     }

--- a/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentService.java
@@ -66,6 +66,7 @@ public class RecruitmentService {
                 .tags((cond.getTags() == null || cond.getTags().isEmpty()) ? null : cond.getTags())
                 .techStackCount((cond.getTechStacks() == null || cond.getTechStacks().isEmpty()) ? null : (long) cond.getTechStacks().size())
                 .tagCount((cond.getTags() == null || cond.getTags().isEmpty()) ? null : (long) cond.getTags().size())
+                .keyword((cond.getKeyword() == null || cond.getKeyword().isBlank()) ? null : cond.getKeyword())
                 .build();
 
         Pageable pageable = PageRequest.of(page, 40);

--- a/src/test/http/recruitment.http
+++ b/src/test/http/recruitment.http
@@ -25,6 +25,10 @@ Authorization: Bearer {{accessToken}}
 GET {{baseUrl}}/recruitments?experienceMin=1&experienceMax=5&education=4&workLocation=경기도 성남시 분당구 판교로 235&salaryMin=3000
 Authorization: Bearer {{accessToken}}
 
+###
+GET {{baseUrl}}/recruitments?techStacks=1
+Authorization: Bearer {{accessToken}}
+
 ### 🗺️ 지도 기반 조회 - 좌표 설정 포함
 GET {{baseUrl}}/recruitments?topLeftLat=37.60&topLeftLng=126.90&bottomRightLat=37.30&bottomRightLng=127.10
 Authorization: Bearer {{accessToken}}

--- a/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
@@ -396,9 +396,9 @@ public class RecruitmentServiceTest {
         RecruitmentSearchConditionDTO condition = RecruitmentSearchConditionDTO.builder().build();
         int page = 0;
 
-        // 50개의 아이템을 생성 (80개만 반환되어야 함)
+        // 130개의 아이템을 생성 (80개만 반환되어야 함)
         List<RecruitmentResponseDTO> mockItems = new ArrayList<>();
-        for (int i = 1; i <= 50; i++) {
+        for (int i = 1; i <= 130; i++) {
             mockItems.add(new RecruitmentResponseDTO(
                 (long) i, "test::" + i, "개발자 모집 " + i, "회사 " + i, "image_" + i + ".jpg",
                 LocalDateTime.now().plusDays(30), // 만료되지 않은 공고

--- a/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
@@ -208,7 +208,7 @@ public class RecruitmentServiceTest {
 
         int page = 0;
         List<RecruitmentResponseDTO> expectedContent = createMockResponseList();
-        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 40);
+        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 80);
 
         when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
             .thenReturn(expectedPage);
@@ -220,7 +220,7 @@ public class RecruitmentServiceTest {
         assertEquals(expectedPage.getContent(), result.getContent());
         verify(recruitmentRepository).findBySearchConditions(
             argThat(cond -> cond.getTechStackCount() == 2L && cond.getTagCount() == 2L),
-            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 40)
+            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 80)
         );
     }
 
@@ -232,7 +232,7 @@ public class RecruitmentServiceTest {
 
         int page = 0;
         List<RecruitmentResponseDTO> expectedContent = createMockResponseList();
-        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 40);
+        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 80);
 
         when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
             .thenReturn(expectedPage);
@@ -244,7 +244,7 @@ public class RecruitmentServiceTest {
         assertEquals(expectedPage.getContent(), result.getContent());
         verify(recruitmentRepository).findBySearchConditions(
             any(RecruitmentSearchConditionDTO.class),
-            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 40)
+            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 80)
         );
     }
 
@@ -261,7 +261,7 @@ public class RecruitmentServiceTest {
 
         int page = 0;
         List<RecruitmentResponseDTO> expectedContent = createMockResponseList();
-        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 40);
+        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 80);
 
         when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
             .thenReturn(expectedPage);
@@ -273,7 +273,7 @@ public class RecruitmentServiceTest {
         assertEquals(expectedPage.getContent(), result.getContent());
         verify(recruitmentRepository).findBySearchConditions(
             any(RecruitmentSearchConditionDTO.class),
-            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 40)
+            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 80)
         );
     }
 
@@ -292,7 +292,7 @@ public class RecruitmentServiceTest {
 
         int page = 0;
         List<RecruitmentResponseDTO> expectedContent = createMockResponseList();
-        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 40);
+        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 80);
 
         when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
             .thenReturn(expectedPage);
@@ -304,7 +304,7 @@ public class RecruitmentServiceTest {
         assertEquals(expectedPage.getContent(), result.getContent());
         verify(recruitmentRepository).findBySearchConditions(
             argThat(cond -> cond.getTechStackCount() == null && cond.getTagCount() == null),
-            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 40)
+            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 80)
         );
     }
 
@@ -319,7 +319,7 @@ public class RecruitmentServiceTest {
 
         int page = 0;
         List<RecruitmentResponseDTO> expectedContent = createMockResponseList();
-        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 40);
+        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 80);
 
         when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
             .thenReturn(expectedPage);
@@ -331,7 +331,7 @@ public class RecruitmentServiceTest {
         assertEquals(expectedPage.getContent(), result.getContent());
         verify(recruitmentRepository).findBySearchConditions(
             argThat(cond -> cond.getTechStackCount() == null && cond.getTagCount() == null),
-            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 40)
+            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 80)
         );
     }
 
@@ -346,7 +346,7 @@ public class RecruitmentServiceTest {
 
         int page = 0;
         List<RecruitmentResponseDTO> expectedContent = createMockResponseList();
-        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 40);
+        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 80);
 
         when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
             .thenReturn(expectedPage);
@@ -358,7 +358,7 @@ public class RecruitmentServiceTest {
         assertEquals(expectedPage.getContent(), result.getContent());
         verify(recruitmentRepository).findBySearchConditions(
             argThat(cond -> cond.getTechStackCount() == 3L && cond.getTagCount() == null),
-            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 40)
+            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 80)
         );
     }
 
@@ -373,7 +373,7 @@ public class RecruitmentServiceTest {
 
         int page = 0;
         List<RecruitmentResponseDTO> expectedContent = createMockResponseList();
-        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 40);
+        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 80);
 
         when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
             .thenReturn(expectedPage);
@@ -385,18 +385,18 @@ public class RecruitmentServiceTest {
         assertEquals(expectedPage.getContent(), result.getContent());
         verify(recruitmentRepository).findBySearchConditions(
             argThat(cond -> cond.getTechStackCount() == null && cond.getTagCount() == 2L),
-            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 40)
+            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 80)
         );
     }
 
     @Test
-    @DisplayName("채용 공고 목록 조회 - 페이지네이션 테스트 (40개 항목)")
-    void listRecruitments_ShouldReturnPageWith40Items() {
+    @DisplayName("채용 공고 목록 조회 - 페이지네이션 테스트 (80 항목)")
+    void listRecruitments_ShouldReturnPageWith80Items() {
         // Given
         RecruitmentSearchConditionDTO condition = RecruitmentSearchConditionDTO.builder().build();
         int page = 0;
 
-        // 50개의 아이템을 생성 (40개만 반환되어야 함)
+        // 50개의 아이템을 생성 (80개만 반환되어야 함)
         List<RecruitmentResponseDTO> mockItems = new ArrayList<>();
         for (int i = 1; i <= 50; i++) {
             mockItems.add(new RecruitmentResponseDTO(
@@ -407,10 +407,10 @@ public class RecruitmentServiceTest {
             ));
         }
 
-        // 첫 페이지에는 40개의 아이템만 포함되어야 함
+        // 첫 페이지에는 80개의 아이템만 포함되어야 함
         Page<RecruitmentResponseDTO> mockPage = new PageImpl<>(
-            mockItems.subList(0, 40), 
-            PageRequest.of(page, 40), 
+            mockItems.subList(0, 80),
+            PageRequest.of(page, 80),
             mockItems.size()
         );
 
@@ -421,12 +421,12 @@ public class RecruitmentServiceTest {
         Page<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition, page);
 
         // Then
-        assertEquals(40, result.getContent().size()); // 페이지당 40개 항목
-        assertEquals(50, result.getTotalElements()); // 전체 50개 항목
-        assertEquals(2, result.getTotalPages()); // 총 2페이지 (40 + 10)
+        assertEquals(80, result.getContent().size()); // 페이지당 80개 항목
+        assertEquals(130, result.getTotalElements()); // 전체 130개 항목
+        assertEquals(2, result.getTotalPages()); // 총 2페이지 (80 + 10)
         verify(recruitmentRepository).findBySearchConditions(
             any(RecruitmentSearchConditionDTO.class),
-            argThat(pageable -> pageable.getPageSize() == 40)
+            argThat(pageable -> pageable.getPageSize() == 80)
         );
     }
 
@@ -448,7 +448,7 @@ public class RecruitmentServiceTest {
             ));
         }
 
-        Page<RecruitmentResponseDTO> mockPage = createMockResponsePage(mockItems, page, 40);
+        Page<RecruitmentResponseDTO> mockPage = createMockResponsePage(mockItems, page, 80);
         when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
             .thenReturn(mockPage);
 
@@ -501,7 +501,7 @@ public class RecruitmentServiceTest {
         }
 
         // 레포지토리는 이미 만료된 공고를 필터링한 결과를 반환해야 함
-        Page<RecruitmentResponseDTO> mockPage = createMockResponsePage(validItems, page, 40);
+        Page<RecruitmentResponseDTO> mockPage = createMockResponsePage(validItems, page, 80);
         when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
             .thenReturn(mockPage);
 
@@ -582,7 +582,7 @@ public class RecruitmentServiceTest {
         List<RecruitmentResponseDTO> matchingItems = List.of(overlapping1, exact, overlapping2);
 
         // 레포지토리는 이미 경력 범위로 필터링한 결과를 반환해야 함
-        Page<RecruitmentResponseDTO> mockPage = createMockResponsePage(matchingItems, page, 40);
+        Page<RecruitmentResponseDTO> mockPage = createMockResponsePage(matchingItems, page, 80);
         when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
             .thenReturn(mockPage);
 
@@ -1089,7 +1089,7 @@ public class RecruitmentServiceTest {
 
         int page = 0;
         List<RecruitmentResponseDTO> expectedContent = createMockResponseList();
-        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 40);
+        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 80);
 
         when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
             .thenReturn(expectedPage);
@@ -1101,7 +1101,7 @@ public class RecruitmentServiceTest {
         assertEquals(expectedPage.getContent(), result.getContent());
         verify(recruitmentRepository).findBySearchConditions(
             argThat(cond -> keyword.equals(cond.getKeyword())),
-            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 40)
+            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 80)
         );
     }
 
@@ -1115,7 +1115,7 @@ public class RecruitmentServiceTest {
 
         int page = 0;
         List<RecruitmentResponseDTO> expectedContent = createMockResponseList();
-        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 40);
+        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 80);
 
         when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
             .thenReturn(expectedPage);
@@ -1127,7 +1127,7 @@ public class RecruitmentServiceTest {
         assertEquals(expectedPage.getContent(), result.getContent());
         verify(recruitmentRepository).findBySearchConditions(
             argThat(cond -> cond.getKeyword() == null),
-            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 40)
+            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 80)
         );
     }
 
@@ -1148,7 +1148,7 @@ public class RecruitmentServiceTest {
 
         int page = 0;
         List<RecruitmentResponseDTO> expectedContent = createMockResponseList();
-        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 40);
+        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 80);
 
         when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
             .thenReturn(expectedPage);
@@ -1168,7 +1168,7 @@ public class RecruitmentServiceTest {
                 cond.getEducation() == 4 &&
                 cond.getTechStackCount() == 2L
             ),
-            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 40)
+            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 80)
         );
     }
 

--- a/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/org/example/hugmeexp/domain/recruitment/service/RecruitmentServiceTest.java
@@ -1079,6 +1079,100 @@ public class RecruitmentServiceTest {
     }
 
     @Test
+    @DisplayName("키워드로 채용 공고 필터링 테스트")
+    void listRecruitments_WithKeyword_ShouldFilterByKeyword() {
+        // Given
+        String keyword = "백엔드";
+        RecruitmentSearchConditionDTO condition = RecruitmentSearchConditionDTO.builder()
+                .keyword(keyword)
+                .build();
+
+        int page = 0;
+        List<RecruitmentResponseDTO> expectedContent = createMockResponseList();
+        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 40);
+
+        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
+            .thenReturn(expectedPage);
+
+        // When
+        Page<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition, page);
+
+        // Then
+        assertEquals(expectedPage.getContent(), result.getContent());
+        verify(recruitmentRepository).findBySearchConditions(
+            argThat(cond -> keyword.equals(cond.getKeyword())),
+            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 40)
+        );
+    }
+
+    @Test
+    @DisplayName("빈 키워드로 채용 공고 필터링 테스트")
+    void listRecruitments_WithEmptyKeyword_ShouldPassNullKeyword() {
+        // Given
+        RecruitmentSearchConditionDTO condition = RecruitmentSearchConditionDTO.builder()
+                .keyword("")
+                .build();
+
+        int page = 0;
+        List<RecruitmentResponseDTO> expectedContent = createMockResponseList();
+        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 40);
+
+        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
+            .thenReturn(expectedPage);
+
+        // When
+        Page<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition, page);
+
+        // Then
+        assertEquals(expectedPage.getContent(), result.getContent());
+        verify(recruitmentRepository).findBySearchConditions(
+            argThat(cond -> cond.getKeyword() == null),
+            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 40)
+        );
+    }
+
+    @Test
+    @DisplayName("키워드와 다른 조건으로 채용 공고 필터링 테스트")
+    void listRecruitments_WithKeywordAndOtherConditions_ShouldFilterCorrectly() {
+        // Given
+        String keyword = "개발자";
+        RecruitmentSearchConditionDTO condition = RecruitmentSearchConditionDTO.builder()
+                .keyword(keyword)
+                .salaryMin(3000)
+                .salaryMax(5000)
+                .experienceMin(3)
+                .experienceMax(7)
+                .education(4)
+                .techStacks(List.of(1L, 2L))
+                .build();
+
+        int page = 0;
+        List<RecruitmentResponseDTO> expectedContent = createMockResponseList();
+        Page<RecruitmentResponseDTO> expectedPage = createMockResponsePage(expectedContent, page, 40);
+
+        when(recruitmentRepository.findBySearchConditions(any(RecruitmentSearchConditionDTO.class), any(Pageable.class)))
+            .thenReturn(expectedPage);
+
+        // When
+        Page<RecruitmentResponseDTO> result = recruitmentService.listRecruitments(condition, page);
+
+        // Then
+        assertEquals(expectedPage.getContent(), result.getContent());
+        verify(recruitmentRepository).findBySearchConditions(
+            argThat(cond -> 
+                keyword.equals(cond.getKeyword()) && 
+                cond.getSalaryMin() == 3000 &&
+                cond.getSalaryMax() == 5000 &&
+                cond.getExperienceMin() == 3 &&
+                cond.getExperienceMax() == 7 &&
+                cond.getEducation() == 4 &&
+                cond.getTechStackCount() == 2L
+            ),
+            argThat(pageable -> pageable.getPageNumber() == page && pageable.getPageSize() == 40)
+        );
+    }
+
+    @Test
     @DisplayName("채용 공고 필터 옵션 조회 테스트")
     void getFilterOptions_ShouldReturnAllFilterOptions() throws Exception {
         // Given


### PR DESCRIPTION
# 🚀 What’s this PR about?

- 채용 공고 목록 필터링 기능 개선 및 키워드 검색 조건 추가

# 🛠️ What’s been done?

- RecruitmentSearchConditionDTO에 keyword 필드 추가
- 중간 엔티티(RecruitmentTechStack, RecruitmentTag) 기준으로 ts.id → ts.techItem.id, t.id → t.tagItem.id 조건으로 변경
- DTO에서 참조하는 id 기준을 TechItem/TagItem 기준으로 통일
- 백엔드에서 페이징 80으로 변경

# 🧪 Testing Details

- 키워드 및 필터 조건 기반 채용 공고 조회 테스트 케이스 추가
- 기술 스택/태그 필터와 키워드 필터를 혼합한 테스트 통과

# 👀 Checkpoints for Reviewers


# 📚 References & Resources


# 🎯 Related Issues

- close#69 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 채용 목록 검색 시 제목 또는 회사명에 대한 키워드 검색 기능이 추가되었습니다.

* **기능 개선**
  * 채용 목록 조회 시 페이지당 표시되는 항목 수가 40개에서 80개로 증가하였습니다.
  * 기술 스택 및 태그 필터링의 정확성이 향상되었습니다.

* **테스트**
  * 키워드 검색 기능과 페이지 크기 변경에 대한 테스트가 추가 및 보강되었습니다.
  * HTTP API 테스트 예시에 기술 스택 필터링 요청이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->